### PR TITLE
database:add command

### DIFF
--- a/config/services/drupal-console/database.yml
+++ b/config/services/drupal-console/database.yml
@@ -1,4 +1,9 @@
 services:
+  console.database_add:
+    class: Drupal\Console\Command\Database\AddCommand
+    arguments: ['@console.database_settings_generator']
+    tags:
+      - { name: drupal.command }
   console.database_client:
     class: Drupal\Console\Command\Database\ClientCommand
     tags:

--- a/config/services/drupal-console/generator.yml
+++ b/config/services/drupal-console/generator.yml
@@ -166,6 +166,11 @@ services:
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }
+  console.database_settings_generator:
+    class: Drupal\Console\Generator\DatabaseSettingsGenerator
+    arguments: ['@kernel']
+    tags:
+      - { name: drupal.generator }
   console.entitycontent_generator:
     class: Drupal\Console\Generator\EntityContentGenerator
     arguments: ['@console.extension_manager', '@console.site', '@console.renderer']

--- a/src/Command/Database/AddCommand.php
+++ b/src/Command/Database/AddCommand.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Database\ConnectCommand.
+ */
+
+namespace Drupal\Console\Command\Database;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+use Drupal\Console\Generator\DatabaseSettingsGenerator;
+use Drupal\Console\Command\Shared\CommandTrait;
+use Drupal\Console\Command\Shared\ConnectTrait;
+use Drupal\Console\Style\DrupalStyle;
+
+class AddCommand extends Command
+{
+    use CommandTrait;
+    use ConnectTrait;
+
+
+    /**
+     * @var DatabaseSettingsGenerator
+     */
+    protected $generator;
+
+    /**
+     * FormCommand constructor.
+     * @param DatabaseSettingsGenerator $generator
+     */
+    public function __construct(
+        DatabaseSettingsGenerator $generator
+    ) {
+        $this->generator = $generator;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('database:add')
+            ->setDescription($this->trans('commands.database.add.description'))
+            ->addOption(
+                'database',
+                '',
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.database.add.options.database')
+            )
+            ->addOption(
+                'username',
+                '',
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.database.add.options.username')
+            )
+            ->addOption(
+                'password',
+                '',
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.database.add.options.password')
+            )
+            ->addOption(
+                'prefix',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.database.add.options.prefix')
+            )
+            ->addOption(
+                'host',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.database.add.options.host')
+            )
+            ->addOption(
+                'port',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.database.add.options.port')
+            )
+            ->addOption(
+                'driver',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.database.add.options.driver')
+            )
+            ->setHelp($this->trans('commands.database.add.help'));
+    }
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $result = $this
+            ->generator
+            ->generate($input->getOptions());
+        if (!$result) {
+          $io->error($this->trans('commands.database.add.error'));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $database = $input->getOption('database');
+        if (!$database) {
+            $database = $io->ask(
+                $this->trans('commands.database.add.questions.database'),
+                'migrate_db'
+            );
+        }
+        $input->setOption('database', $database);
+        $username = $input->getOption('username');
+        if (!$username) {
+            $username = $io->ask(
+                $this->trans('commands.database.add.questions.username'),
+                ''
+            );
+        }
+        $input->setOption('username', $username);
+        $password = $input->getOption('password');
+        if (!$password) {
+            $password = $io->ask(
+                $this->trans('commands.database.add.questions.password'),
+                ''
+            );
+        }
+        $input->setOption('password', $password);
+        $prefix = $input->getOption('prefix');
+        if (!$prefix) {
+            $prefix = $io->ask(
+                $this->trans('commands.database.add.questions.prefix'),
+                FALSE
+            );
+        }
+        $input->setOption('prefix', $prefix);
+        $host = $input->getOption('host');
+        if (!$host) {
+            $host = $io->ask(
+                $this->trans('commands.database.add.questions.host'),
+                'localhost'
+            );
+        }
+        $input->setOption('host', $host);
+        $port = $input->getOption('port');
+        if (!$port) {
+            $port = $io->ask(
+                $this->trans('commands.database.add.questions.port'),
+                3306
+            );
+        }
+        $input->setOption('port', $port);
+        $driver = $input->getOption('driver');
+        if (!$driver) {
+            $driver = $io->ask(
+                $this->trans('commands.database.add.questions.driver'),
+                'mysql'
+            );
+        }
+        $input->setOption('driver', $driver);
+    }
+}

--- a/src/Generator/DatabaseSettingsGenerator.php
+++ b/src/Generator/DatabaseSettingsGenerator.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Generator\DatabaseSettingsGenerator.
+ */
+
+namespace Drupal\Console\Generator;
+
+use Drupal\Core\DrupalKernelInterface;
+
+class DatabaseSettingsGenerator extends Generator
+{
+
+    /**
+     * @var DrupalKernelInterface
+     */
+    protected $kernel;
+
+    /**
+     * DatabaseSettingsGenerator constructor.
+     * @param DrupalKernelInterface $kernel
+     */
+    public function __construct(
+        DrupalKernelInterface $kernel
+    ) {
+        $this->kernel = $kernel;
+    }
+
+
+    /**
+     * Generator Plugin Block.
+     *
+     * @param $parameters
+     */
+    public function generate($parameters)
+    {
+        $settingsFile = $this->kernel->getSitePath().'/settings.php';
+        if (!is_writable($settingsFile)) {
+          return false;
+        }
+        return $this->renderFile(
+            'database/add.php.twig',
+            $settingsFile,
+            $parameters,
+            FILE_APPEND
+        );
+    }
+}

--- a/templates/database/add.php.twig
+++ b/templates/database/add.php.twig
@@ -1,0 +1,10 @@
+
+$databases['default']['{{ database }}'] = [
+  'database' => '{{ database }}',
+  'username' => '{{ username }}',
+  'password' => '{{ password }}',
+  'host' => '{{ host }}',
+  'port' => '{{ port }}',
+  'driver' => '{{ driver }}',
+  'prefix' => '{{ prefix }}',
+];

--- a/templates/database/add.php.twig
+++ b/templates/database/add.php.twig
@@ -1,5 +1,5 @@
 
-$databases['default']['{{ database }}'] = [
+$databases['{{ database }}']['default'] = [
   'database' => '{{ database }}',
   'username' => '{{ username }}',
   'password' => '{{ password }}',


### PR DESCRIPTION
Adds a database (with hints/defaults) to the site's settings.php - ie for use with migrate etc. see also PR on drupal-console-en coming up next.