### PR TITLE
generate:plugin:migrate:source

### DIFF
--- a/config/services/drupal-console/generate.yml
+++ b/config/services/drupal-console/generate.yml
@@ -99,6 +99,11 @@ services:
     arguments: ['@console.extension_manager', '@console.plugin_mail_generator','@console.string_converter', '@console.validator', '@console.chain_queue']
     tags:
        - { name: drupal.command }
+  console.generate_plugin_migrate_source:
+    class: Drupal\Console\Command\Generate\PluginMigrateSourceCommand
+    arguments: ['@config.factory', '@console.chain_queue', '@console.plugin_migrate_source_generator', '@entity_type.manager', '@console.extension_manager', '@console.validator', '@console.string_converter', '@plugin.manager.element_info']
+    tags:
+       - { name: drupal.command }
   console.generate_plugin_rest_resource:
     class: Drupal\Console\Command\Generate\PluginRestResourceCommand
     arguments: ['@console.extension_manager', '@console.plugin_rest_resource_generator','@console.string_converter', '@console.chain_queue']

--- a/config/services/drupal-console/generator.yml
+++ b/config/services/drupal-console/generator.yml
@@ -96,6 +96,11 @@ services:
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }
+  console.plugin_migrate_source_generator:
+    class: Drupal\Console\Generator\PluginMigrateSourceGenerator
+    arguments: ['@console.extension_manager']
+    tags:
+      - { name: drupal.generator }
   console.plugin_rest_resource_generator:
     class: Drupal\Console\Generator\PluginRestResourceGenerator
     arguments: ['@console.extension_manager']

--- a/src/Command/Generate/PluginMigrateSourceCommand.php
+++ b/src/Command/Generate/PluginMigrateSourceCommand.php
@@ -196,7 +196,7 @@ class PluginMigrateSourceCommand extends Command
         if (!$class) {
             $class = $io->ask(
                 $this->trans('commands.generate.plugin.migrate.source.questions.class'),
-                $this->stringConverter->underscoreToCamelCase($module),
+                ucfirst($this->stringConverter->underscoreToCamelCase($module)),
                 function ($class) {
                     return $this->validator->validateClassName($class);
                 }

--- a/src/Command/Generate/PluginMigrateSourceCommand.php
+++ b/src/Command/Generate/PluginMigrateSourceCommand.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Generate\PluginBlockCommand.
+ */
+
+namespace Drupal\Console\Command\Generate;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+use Drupal\Console\Generator\PluginMigrateSourceGenerator;
+use Drupal\Console\Command\Shared\ModuleTrait;
+use Drupal\Console\Command\Shared\ConfirmationTrait;
+use Drupal\Console\Command\Shared\ContainerAwareCommandTrait;
+use Drupal\Console\Extension\Manager;
+use Drupal\Console\Utils\Validator;
+use Drupal\Console\Utils\StringConverter;
+use Drupal\Console\Style\DrupalStyle;
+use Drupal\Console\Utils\ChainQueue;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\ElementInfoManagerInterface;
+
+class PluginMigrateSourceCommand extends Command
+{
+    use ModuleTrait;
+    use ConfirmationTrait;
+    use ContainerAwareCommandTrait;
+
+    /**
+     * @var ConfigFactory
+     */
+    protected $configFactory;
+
+    /**
+     * @var ChainQueue
+     */
+    protected $chainQueue;
+
+    /**
+     * @var PluginMigrateSourceGenerator
+     */
+    protected $generator;
+
+    /**
+     * @var EntityTypeManagerInterface
+     */
+    protected $entityTypeManager;
+
+    /**
+     * @var Manager
+     */
+    protected $extensionManager;
+
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    /**
+     * @var StringConverter
+     */
+    protected $stringConverter;
+
+    /**
+     * @var ElementInfoManagerInterface
+     */
+    protected $elementInfoManager;
+
+    /**
+     * PluginBlockCommand constructor.
+     * @param ConfigFactory               $configFactory
+     * @param ChainQueue                  $chainQueue
+     * @param PluginBlockGenerator        $generator
+     * @param EntityTypeManagerInterface  $entityTypeManager
+     * @param Manager                     $extensionManager
+     * @param Validator                   $validator
+     * @param StringConverter             $stringConverter
+     * @param ElementInfoManagerInterface $elementInfoManager
+     */
+    public function __construct(
+        ConfigFactory $configFactory,
+        ChainQueue $chainQueue,
+        PluginMigrateSourceGenerator $generator,
+        EntityTypeManagerInterface $entityTypeManager,
+        Manager $extensionManager,
+        Validator $validator,
+        StringConverter $stringConverter,
+        ElementInfoManagerInterface $elementInfoManager
+    ) {
+        $this->configFactory = $configFactory;
+        $this->chainQueue = $chainQueue;
+        $this->generator = $generator;
+        $this->entityTypeManager = $entityTypeManager;
+        $this->extensionManager = $extensionManager;
+        $this->validator = $validator;
+        $this->stringConverter = $stringConverter;
+        $this->elementInfoManager = $elementInfoManager;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('generate:plugin:migrate:source')
+            ->setDescription($this->trans('commands.generate.plugin.migrate.source.description'))
+            ->setHelp($this->trans('commands.generate.plugin.migrate.source.help'))
+            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption(
+                'class',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.plugin.migrate.source.options.class')
+            )
+            ->addOption(
+                'plugin-id',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.plugin.migrate.source.options.plugin-id')
+            )
+            ->addOption(
+                'table',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.plugin.migrate.source.options.table')
+            )
+            ->addOption(
+                'alias',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.plugin.migrate.source.options.alias')
+            )
+            ->addOption(
+                'group-by',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.plugin.migrate.source.options.group-by')
+            )
+            ->addOption(
+                'fields',
+                '',
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $this->trans('commands.generate.plugin.migrate.source.options.fields')
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        // @see use Drupal\Console\Command\Shared\ConfirmationTrait::confirmGeneration
+        if (!$this->confirmGeneration($io)) {
+            return 1;
+        }
+
+        $module = $input->getOption('module');
+        $class_name = $input->getOption('class');
+        $plugin_id = $input->getOption('plugin-id');
+        $table = $input->getOption('table');
+        $alias = $input->getOption('alias');
+        $group_by = $input->getOption('group-by');
+        $fields = $input->getOption('fields');
+
+        $this->generator
+            ->generate(
+                $module,
+                $class_name,
+                $plugin_id,
+                $table,
+                $alias,
+                $group_by,
+                $fields
+            );
+
+        $this->chainQueue->addCommand('cache:rebuild', ['cache' => 'discovery']);
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $module = $input->getOption('module');
+        if (!$module) {
+            // @see Drupal\Console\Command\Shared\ModuleTrait::moduleQuestion
+            $module = $this->moduleQuestion($io);
+            $input->setOption('module', $module);
+        }
+
+        $class = $input->getOption('class');
+        if (!$class) {
+            $class = $io->ask(
+                $this->trans('commands.generate.plugin.migrate.source.questions.class'),
+                $this->stringConverter->underscoreToCamelCase($module),
+                function ($class) {
+                    return $this->validator->validateClassName($class);
+                }
+            );
+            $input->setOption('class', $class);
+        }
+
+        $pluginId = $input->getOption('plugin-id');
+        if (!$pluginId) {
+            $pluginId = $io->ask(
+                $this->trans('commands.generate.plugin.migrate.source.questions.plugin-id'),
+                $this->stringConverter->camelCaseToUnderscore($class)
+            );
+            $input->setOption('plugin-id', $pluginId);
+        }
+
+        $table = $input->getOption('table');
+        if (!$table) {
+            $table = $io->ask(
+                $this->trans('commands.generate.plugin.migrate.source.questions.table'),
+                ''
+            );
+            $input->setOption('table', $table);
+        }
+
+        $alias = $input->getOption('alias');
+        if (!$alias) {
+            $alias = $io->ask(
+                $this->trans('commands.generate.plugin.migrate.source.questions.alias'),
+                substr($table, 0, 1)
+            );
+            $input->setOption('alias', $alias);
+        }
+
+        $groupBy = $input->getOption('group-by');
+        if ($groupBy == '') {
+            $groupBy = $io->ask(
+                $this->trans('commands.generate.plugin.migrate.source.questions.group-by'),
+                false
+            );
+            $input->setOption('group-by', $groupBy);
+        }
+
+        $fields = $input->getOption('fields');
+        if (!$fields) {
+            $fields = [];
+            while(true) {
+                $id = $io->ask(
+                    $this->trans('commands.generate.plugin.migrate.source.questions.fields.id'),
+                    false
+                );
+                if (!$id) {
+                    break;
+                }
+                $description = $io->ask(
+                    $this->trans('commands.generate.plugin.migrate.source.questions.fields.description'),
+                    $id
+                );
+                $fields[] = [
+                    'id' => $id,
+                    'description' => $description,
+                ];
+            }
+            $input->setOption('fields', $fields);
+        }
+    }
+}

--- a/src/Generator/PluginMigrateSourceGenerator.php
+++ b/src/Generator/PluginMigrateSourceGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Generator\PluginMigrateSourceGenerator.
+ */
+
+namespace Drupal\Console\Generator;
+
+use Drupal\Console\Extension\Manager;
+
+class PluginMigrateSourceGenerator extends Generator
+{
+    /**
+     * @var Manager
+     */
+    protected $extensionManager;
+
+    /**
+     * PluginMigrateSourceGenerator constructor.
+     * @param Manager $extensionManager
+     */
+    public function __construct(
+        Manager $extensionManager
+    ) {
+        $this->extensionManager = $extensionManager;
+    }
+
+    /**
+     * Generate Migrate Source plugin code.
+     *
+     * @param $module
+     * @param $class_name
+     * @param $plugin_id
+     * @param $table
+     * @param $alias
+     * @param $group_by
+     * @param fields
+     */
+    public function generate($module, $class_name, $plugin_id, $table, $alias, $group_by, $fields)
+    {
+
+        $parameters = [
+          'module' => $module,
+          'class_name' => $class_name,
+          'plugin_id' => $plugin_id,
+          'table' => $table,
+          'alias' => $alias,
+          'group_by' => $group_by,
+          'fields' => $fields,
+        ];
+
+        $this->renderFile(
+            'module/src/Plugin/migrate/source/source.php.twig',
+            $this->extensionManager->getPluginPath($module, 'migrate').'/source/'.$class_name.'.php',
+            $parameters
+        );
+    }
+}

--- a/templates/module/src/Plugin/migrate/source/source.php.twig
+++ b/templates/module/src/Plugin/migrate/source/source.php.twig
@@ -28,7 +28,7 @@ class {{class_name}} extends SqlBase {% endblock %}
   public function query() {
 
     return $this->select('{{table}}', '{{alias}}')
-      ->fields('{{alias}}']){% if group_by %}
+      ->fields('{{alias}}'){% if group_by %}
       ->groupBy('{{alias}}.{{group_by}}')
       {% endif %};
   }
@@ -39,9 +39,9 @@ class {{class_name}} extends SqlBase {% endblock %}
   public function fields() {
     $fields = [
     {% for field in fields %}
-      '{{field.id}}' => $this->t('{{field.description}}'),
+  '{{field.id}}' => $this->t('{{field.description}}'),
     {% endfor %}
-    ];
+];
     return $fields;
   }
 
@@ -52,5 +52,4 @@ class {{class_name}} extends SqlBase {% endblock %}
     return [
     ];
   }
-
 {% endblock %}

--- a/templates/module/src/Plugin/migrate/source/source.php.twig
+++ b/templates/module/src/Plugin/migrate/source/source.php.twig
@@ -1,0 +1,56 @@
+{% extends "base/class.php.twig" %}
+
+{% block file_path %}
+\Drupal\{{module}}\Plugin\migrate\source\{{class_name}}.
+{% endblock %}
+
+{% block namespace_class %}
+namespace Drupal\{{module}}\Plugin\migrate\source;
+{% endblock %}
+
+{% block use_class %}
+use Drupal\migrate\Plugin\migrate\source\SqlBase;
+{% endblock %}
+
+{% block class_declaration %}
+/**
+ * Provides a '{{class_name}}' migrate source.
+ *
+ * @MigrateSource(
+ *  id = "{{plugin_id}}"
+ * )
+ */
+class {{class_name}} extends SqlBase {% endblock %}
+{% block class_methods %}
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+
+    return $this->select('{{table}}', '{{alias}}')
+      ->fields('{{alias}}']){% if group_by %}
+      ->groupBy('{{alias}}.{{group_by}}')
+      {% endif %};
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+    {% for field in fields %}
+      '{{field.id}}' => $this->t('{{field.description}}'),
+    {% endfor %}
+    ];
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return [
+    ];
+  }
+
+{% endblock %}


### PR DESCRIPTION
Currently uses sqlBase so perhaps should consider actually naming it ..:source:sqlbase? (see templates/module/src/Plugin/migrate/source/source.php.twig) english strings PR as well