### PR TITLE
Fix constructor args in two commands (#3041)

### DIFF
--- a/src/Command/Config/ValidateCommand.php
+++ b/src/Command/Config/ValidateCommand.php
@@ -27,12 +27,6 @@ class ValidateCommand extends Command
     use SchemaCheckTrait;
     use PrintConfigValidationTrait;
 
-    public function __construct($name)
-    {
-        parent::__construct($name);
-    }
-
-
     /**
    * {@inheritdoc}
    */

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -78,7 +78,7 @@ class ModuleCommand extends Command
      * @param DrupalApi       $drupalApi
      * @param Client          $httpClient
      * @param Site            $site
-     * @param               $twigtemplate
+     * @param                 $twigtemplate
      */
     public function __construct(
         ModuleGenerator $generator,
@@ -88,7 +88,7 @@ class ModuleCommand extends Command
         DrupalApi $drupalApi,
         Client $httpClient,
         Site $site,
-        $twigtemplate
+        $twigtemplate = NULL
     ) {
         $this->generator = $generator;
         $this->validator = $validator;


### PR DESCRIPTION
- config:validate overrides the parent constructor's optional
  name argument with a constructor that requires it.

- generate:module requires an argument that is not defined in
  the corresponding services file, and should be optional.