### PR TITLE
[console] use a more recent alchemy/zipper which fixes GNU tar usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": "^5.5.9 || ^7.0",
         "drupal/console-core" : "dev-master",
-        "alchemy/zippy": "0.3.5",
+        "alchemy/zippy": "0.4.3",
         "composer/installers": "~1.0",
         "symfony/css-selector": ">=2.7 <3.2",
         "symfony/dom-crawler": ">=2.7 <3.2",


### PR DESCRIPTION
Dear maintainers,

this change is a first step to fix #2584.

I only changed composer.json, I thought I'd let you update the lock file as you have a clearer picture of what all the dependencies should be.

Thanks,
   Antonio