### PR TITLE
Allow usage of features:import with features_ui disabled

### DIFF
--- a/src/Command/Features/ImportCommand.php
+++ b/src/Command/Features/ImportCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Command\Command;
 
 /**
  * @DrupalCommand(
- *     extension = "features_ui",
+ *     extension = "features",
  *     extensionType = "module"
  * )
  */


### PR DESCRIPTION
Before this commit, the features:debug command was available without the
UI module enabled but features:import was not. Since the console
commands do not depend on the UI this commit allows feature imports with
the UI module disabled.

@miguel303 - any thoughts or objections?