### PR TITLE
Don't crash on updates in installation profiles

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -185,8 +185,14 @@ class ExecuteCommand extends Command
     private function runUpdates(DrupalStyle $io, $updates)
     {
         foreach ($updates as $module_name => $module_updates) {
-            $this->site
-                ->loadLegacyFile($this->extensionManager->getModule($module_name)->getPath() . '/'. $module_name . '.install', false);
+            $extension = $this->extensionManager->getModule($module_name);
+            if (!$extension) {
+                $extension = $this->extensionManager->getProfile($module_name);
+            }
+            if ($extension) {
+                $this->site
+                    ->loadLegacyFile($extension->getPath() . '/'. $module_name . '.install', false);
+            }
 
             foreach ($module_updates['pending'] as $update_number => $update) {
                 if ($this->module != 'all' && $this->update_n !== null && $this->update_n != $update_number) {

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -240,6 +240,19 @@ class Manager
      * @param string $name
      * @return \Drupal\Console\Extension\Extension
      */
+    public function getProfile($name)
+    {
+        if ($extension = $this->getExtension('profile', $name)) {
+            return $this->createExtension($extension);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $name
+     * @return \Drupal\Console\Extension\Extension
+     */
     public function getTheme($name)
     {
         if ($extension = $this->getExtension('theme', $name)) {


### PR DESCRIPTION
When running 'update:execute' on an installation profile, drupal console
crashes because it assumes every update belongs to a module while in
practice installation profiles too can contain updates.