### PR TITLE
Allow commands to return an exit code

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -53,12 +53,16 @@ class Application extends BaseApplication
         if ($clear === true || $clear === 'true') {
             $output->write(sprintf("\033\143"));
         }
-        parent::doRun($input, $output);
+
+        $exitCode = parent::doRun($input, $output);
+
         if ($this->getCommandName($input) == 'list' && $this->container->hasParameter('console.warning')) {
             $io->warning(
                 $this->trans($this->container->getParameter('console.warning'))
             );
         }
+
+        return $exitCode;
     }
 
     private function registerGenerators()


### PR DESCRIPTION
It is important for any program to exit with a non-zero exit code if it
encountered an error.

In Symfony console commands it's common to return with an exit code in
the execute() method of a command. Drupal Console disregards this exit
code in Application::doRun(), making it harder to use Drupal Console
in a scriptable way.