### PR TITLE
Use Symfony Process TTY detection, handle no-tty gracefully for server command

### DIFF
--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -96,7 +96,7 @@ class ServerCommand extends Command
 
         $processBuilder = new ProcessBuilder(explode(' ', $cli));
         $processBuilder->setTimeout(NULL);
-        $processBuilder->setWorkingDirectory($this->getDrupalHelper()->getRoot());
+        $processBuilder->setWorkingDirectory($this->appRoot);
 
         $process = $processBuilder->getProcess();
         try {

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -10,6 +10,7 @@ namespace Drupal\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\ProcessBuilder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Console\Command\Command;


### PR DESCRIPTION
Hey!
The TTY detection for the server command is a little strange.  It looks like the Process class is capable of doing it's own TTY detection, throwing an exception if you can't use TTY.  I'd propose just using that, and falling back gracefully to printing the output if a TTY session can't be started.  