### PR TITLE
Add location for contributed database drivers

### DIFF
--- a/src/Utils/Site.php
+++ b/src/Utils/Site.php
@@ -66,6 +66,7 @@ class Site
         $finder = new Finder();
         $finder->directories()
             ->in($this->appRoot . '/core/lib/Drupal/Core/Database/Driver')
+            ->in($this->appRoot . '/drivers/lib/Drupal/Driver/Database')
             ->depth('== 0');
 
         $databases = [];


### PR DESCRIPTION
Currently the drupal console is unable to find contributed database drivers, as it is not discovering the location where these drivers are supposed to be deployed to.