### PR TITLE
cron:execute allow no module name to trigger cron

### DIFF
--- a/src/Command/Cron/ExecuteCommand.php
+++ b/src/Command/Cron/ExecuteCommand.php
@@ -72,7 +72,7 @@ class ExecuteCommand extends Command
             ->setDescription($this->trans('commands.cron.execute.description'))
             ->addArgument(
                 'module',
-                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
                 $this->trans('commands.common.options.module')
             );
     }
@@ -91,7 +91,7 @@ class ExecuteCommand extends Command
             return 1;
         }
 
-        if (in_array('all', $modules)) {
+        if ( $modules === NULL || in_array('all', $modules)) {
             $modules = $this->moduleHandler->getImplementations('cron');
         }
 


### PR DESCRIPTION
See issue https://github.com/hechoendrupal/drupal-console/issues/3126