### PR TITLE
[update:execute] Fix a missing variable argument.

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -127,7 +127,7 @@ class ExecuteCommand extends Command
         drupal_load_updates();
         update_fix_compatibility();
         $updates = update_get_update_list();
-        $updates = $this->checkUpdates($io, $updates);
+        $this->checkUpdates($io, $updates);
         $maintenance_mode = $this->state->get('system.maintenance_mode', false);
 
         if (!$maintenance_mode) {
@@ -149,9 +149,9 @@ class ExecuteCommand extends Command
 
     /**
      * @param \Drupal\Console\Core\Style\DrupalStyle $io
-     * @param $updates
+     * @param array $updates
      */
-    private function checkUpdates(DrupalStyle $io, $updates)
+    private function checkUpdates(DrupalStyle $io, array &$updates)
     {
         if ($this->module != 'all') {
             if (!isset($updates[$this->module])) {
@@ -161,7 +161,6 @@ class ExecuteCommand extends Command
                         $this->module
                     )
                 );
-                $updates = [];
             } else {
                 // filter to execute only a specific module updates
                 $updates = [$this->module => $updates[$this->module]];
@@ -177,7 +176,6 @@ class ExecuteCommand extends Command
                 }
             }
         }
-        return $updates;
     }
 
     /**

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -127,7 +127,7 @@ class ExecuteCommand extends Command
         drupal_load_updates();
         update_fix_compatibility();
         $updates = update_get_update_list();
-        $this->checkUpdates($io);
+        $updates = $this->checkUpdates($io, $updates);
         $maintenance_mode = $this->state->get('system.maintenance_mode', false);
 
         if (!$maintenance_mode) {
@@ -149,8 +149,9 @@ class ExecuteCommand extends Command
 
     /**
      * @param \Drupal\Console\Core\Style\DrupalStyle $io
+     * @param $updates
      */
-    private function checkUpdates(DrupalStyle $io)
+    private function checkUpdates(DrupalStyle $io, $updates)
     {
         if ($this->module != 'all') {
             if (!isset($updates[$this->module])) {
@@ -160,7 +161,7 @@ class ExecuteCommand extends Command
                         $this->module
                     )
                 );
-                return;
+                $updates = [];
             } else {
                 // filter to execute only a specific module updates
                 $updates = [$this->module => $updates[$this->module]];
@@ -176,6 +177,7 @@ class ExecuteCommand extends Command
                 }
             }
         }
+        return $updates;
     }
 
     /**

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -161,6 +161,7 @@ class ExecuteCommand extends Command
                         $this->module
                     )
                 );
+                $updates = [];
             } else {
                 // filter to execute only a specific module updates
                 $updates = [$this->module => $updates[$this->module]];


### PR DESCRIPTION
Fixes #3108 and allows `drupal update:execute <module>` to work.