### PR TITLE
[update:execute] Errors in update code (#3108, #3137)

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -46,8 +46,8 @@ class ExecuteCommand extends Command
 
 
     /**
- * @var Manager
-*/
+     * @var Manager
+     */
     protected $extensionManager;
 
     /**
@@ -254,15 +254,6 @@ class ExecuteCommand extends Command
         $postUpdates = $this->postUpdateRegistry->getPendingUpdateInformation();
         foreach ($postUpdates as $module_name => $module_updates) {
             foreach ($module_updates['pending'] as $update_name => $update) {
-                if ($this->module != 'all' && $this->update_n !== null && $this->update_n != $update_number) {
-                    continue;
-                }
-
-                if ($this->update_n > $module_updates['start']) {
-                    $io->info(
-                        $this->trans('commands.update.execute.messages.executing-required-previous-updates')
-                    );
-                }
                 $io->info(
                     sprintf(
                         $this->trans('commands.update.execute.messages.executing-update'),

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -102,7 +102,7 @@ class ExecuteCommand extends Command
             ->setDescription($this->trans('commands.update.execute.description'))
             ->addArgument(
                 'module',
-                InputArgument::REQUIRED,
+                InputArgument::OPTIONAL,
                 $this->trans('commands.common.options.module')
             )
             ->addArgument(
@@ -118,7 +118,7 @@ class ExecuteCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new DrupalStyle($input, $output);
-        $this->module = $input->getArgument('module');
+        $this->module = $input->getArgument('module') ?: 'all';
         $this->update_n = $input->getArgument('update-n');
 
         $this->site->loadLegacyFile('/core/includes/install.inc');

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -127,7 +127,7 @@ class ExecuteCommand extends Command
         drupal_load_updates();
         update_fix_compatibility();
         $updates = update_get_update_list();
-        $this->checkUpdates($io);
+        $this->checkUpdates($io, $updates);
         $maintenance_mode = $this->state->get('system.maintenance_mode', false);
 
         if (!$maintenance_mode) {
@@ -149,8 +149,9 @@ class ExecuteCommand extends Command
 
     /**
      * @param \Drupal\Console\Core\Style\DrupalStyle $io
+     * @param array $updates
      */
-    private function checkUpdates(DrupalStyle $io)
+    private function checkUpdates(DrupalStyle $io, array &$updates)
     {
         if ($this->module != 'all') {
             if (!isset($updates[$this->module])) {
@@ -160,7 +161,7 @@ class ExecuteCommand extends Command
                         $this->module
                     )
                 );
-                return;
+                $updates = [];
             } else {
                 // filter to execute only a specific module updates
                 $updates = [$this->module => $updates[$this->module]];


### PR DESCRIPTION
This fixes a few bugs (particularly #3108 and #3137) in applying schema updates and post-update functions. As a result, the update command will also return exit code 1 in case of errors.