### PR TITLE
Fix revisions tab for generated content entity

### DIFF
--- a/templates/module/src/Controller/entity-controller.php.twig
+++ b/templates/module/src/Controller/entity-controller.php.twig
@@ -139,10 +139,10 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
               'title' => $this->t('Revert'),
 {% if is_translatable %}
               'url' => $has_translations ?
-              Url::fromRoute('{{ entity_name }}.revision_revert_translation_confirm', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid, 'langcode' => $langcode]) :
-              Url::fromRoute('{{ entity_name }}.revision_revert_confirm', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
+              Url::fromRoute('entity.{{ entity_name }}.translation_revert', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid, 'langcode' => $langcode]) :
+              Url::fromRoute('entity.{{ entity_name }}.revision_revert', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
 {%  else %}
-              'url' => Url::fromRoute('{{ entity_name }}.revision_revert_confirm', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
+              'url' => Url::fromRoute('entity.{{ entity_name }}.revision_revert', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
 {% endif %}
             ];
           }
@@ -150,7 +150,7 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
           if ($delete_permission) {
             $links['delete'] = [
               'title' => $this->t('Delete'),
-              'url' => Url::fromRoute('{{ entity_name }}.revision_delete_confirm', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
+              'url' => Url::fromRoute('entity.{{ entity_name }}.revision_delete', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]),
             ];
           }
 

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -351,6 +351,8 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
       ->setSetting('target_type', 'user')
       ->setQueryable(FALSE)
       ->setRevisionable(TRUE);
+{% endif %}
+{% if revisionable and is_translatable %}
 
     $fields['revision_translation_affected'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Revision translation affected'))

--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -45,11 +45,11 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
     }
 
     if ($revert_route = $this->getRevisionRevertRoute($entity_type)) {
-      $collection->add("{$entity_type_id}.revision_revert_confirm", $revert_route);
+      $collection->add("entity.{$entity_type_id}.revision_revert", $revert_route);
     }
 
     if ($delete_route = $this->getRevisionDeleteRoute($entity_type)) {
-      $collection->add("{$entity_type_id}.revision_delete_confirm", $delete_route);
+      $collection->add("entity.{$entity_type_id}.revision_delete", $delete_route);
     }
 {% if is_translatable %}
 


### PR DESCRIPTION
When using the generated content entity, errors occur, when displaying the revisions tab for that entity type.

```
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "MYENTITY.revision_revert" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 187 of [...]/core/lib/Drupal/Core/Routing/RouteProvider.php).
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "MYENTITY.revision_revert_confirm" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 187 of [...]/core/lib/Drupal/Core/Routing/RouteProvider.php).
```

In addition for _revisionable_ but not _translatable_ entities, no revisions are displayed at all, as _ revision_translation_affected_ is not set. Therefore I guess it is better to remove the `revision_translation_affected` when entity is not translatable.
