### PR TITLE
[composer] Fix psy/psysh version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "gabordemooij/redbean": "~4.3",
         "doctrine/annotations": "1.2.*",
         "symfony/expression-language": ">=2.7 <3.0",
-        "psy/psysh": "0.6|0.8"
+        "psy/psysh": "0.6.* || ~0.8"
     },
     "bin": ["bin/drupal"],
     "config": {


### PR DESCRIPTION
# Problem/Motivation

This is a simple composer version syntax error that was introduced in https://github.com/hechoendrupal/drupal-console/commit/db1d0868 with no context. The or operator is || not |. See https://getcomposer.org/doc/articles/versions.md

# Details

My project already pulls in psy/psysh at version 0.8.1. Drupal/console tries to resolve an unknown version and fails verbosely:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - drupal/console 1.0.0-rc15 requires doctrine/collections 1.3.0 -> satisfiable by doctrine/collections[v1.3.0].
    - Conclusion: don't install doctrine/collections v1.3.0
    - Conclusion: don't install psy/psysh v0.8.0
    - drupal/console 1.0.0-rc13 requires psy/psysh 0.6|0.8 -> satisfiable by psy/psysh[v0.6.0, v0.8.0].
    - drupal/console 1.0.0-rc14 requires psy/psysh 0.6|0.8 -> satisfiable by psy/psysh[v0.6.0, v0.8.0].
    - Conclusion: don't install psy/psysh v0.6.0
    - Conclusion: don't install drupal/console 1.0.0-rc12
    - Conclusion: don't install drupal/console 1.0.0-rc11
    - Conclusion: don't install drupal/console 1.0.0-rc10
    - drupal/console 1.0.0-alpha1 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc1 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc2 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc3 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc4 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc5 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc6 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc7 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc8 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - drupal/console 1.0.0-rc9 requires symfony/css-selector ~2.8 -> satisfiable by symfony/css-selector[2.8.x-dev].
    - Conclusion: don't install symfony/css-selector 2.8.x-dev
    - Conclusion: remove symfony/dom-crawler v3.2.2
    - Conclusion: don't install drupal/console 1.0.0-beta5
    - Conclusion: don't install drupal/console 1.0.0-beta4
    - Conclusion: don't install drupal/console 1.0.0-beta3
    - Conclusion: don't install drupal/console 1.0.0-beta2
    - Conclusion: don't install drupal/console 1.0.0-beta1
    - Conclusion: don't install symfony/dom-crawler v2.8.16
    - Installation request for doctrine/collections (locked at v1.4.0) -> satisfiable by doctrine/collections[v1.4.0].
    - Installation request for psy/psysh (locked at v0.8.1) -> satisfiable by psy/psysh[v0.8.1].
    - Installation request for symfony/css-selector (locked at v2.7.23, required as 2.7.*) -> satisfiable by symfony/css-selector[v2.7.23].
    - Installation request for drupal/console ~1.0 -> satisfiable by drupal/console[1.0.0-alpha1, 1.0.0-alpha2, 1.0.0-beta1, 1.0.0-beta2, 1.0.0-beta3, 1.0.0-beta4, 1.0.0-beta5, 1.0.0-rc1, 1.0.0-rc10, 1.0.0-rc11, 1.0.0-rc12, 1.0.0-rc13, 1.0.0-rc14, 1.0.0-rc15, 1.0.0-rc2, 1.0.0-rc3, 1.0.0-rc4, 1.0.0-rc5, 1.0.0-rc6, 1.0.0-rc7, 1.0.0-rc8, 1.0.0-rc9].
    - Conclusion: don't install symfony/dom-crawler v3.2.2
    - drupal/console 1.0.0-alpha2 requires symfony/dom-crawler ~2.7 -> satisfiable by symfony/dom-crawler[2.7.x-dev, 2.8.x-dev, v2.7.0, v2.7.0-BETA1, v2.7.0-BETA2, v2.7.1, v2.7.10, v2.7.11, v2.7.12, v2.7.13, v2.7.14, v2.7.15, v2.7.16, v2.7.17, v2.7.18, v2.7.19, v2.7.2, v2.7.20, v2.7.21, v2.7.22, v2.7.23, v2.7.3, v2.7.4, v2.7.5, v2.7.6, v2.7.7, v2.7.8, v2.7.9, v2.8.0, v2.8.0-BETA1, v2.8.1, v2.8.10, v2.8.11, v2.8.12, v2.8.13, v2.8.14, v2.8.15, v2.8.16, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v2.8.9].
    - Can only install one of: symfony/dom-crawler[2.8.x-dev, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.13, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.14, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.15, v3.2.2].
    - Can only install one of: symfony/dom-crawler[2.7.x-dev, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.0, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.0-BETA1, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.0-BETA2, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.1, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.10, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.11, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.12, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.13, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.14, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.15, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.16, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.17, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.18, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.19, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.2, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.20, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.21, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.22, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.23, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.3, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.4, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.5, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.6, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.7, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.8, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.7.9, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.0, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.0-BETA1, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.1, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.10, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.11, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.12, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.2, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.3, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.4, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.5, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.6, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.7, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.8, v3.2.2].
    - Can only install one of: symfony/dom-crawler[v2.8.9, v3.2.2].
    - Installation request for symfony/dom-crawler (locked at v3.2.2) -> satisfiable by symfony/dom-crawler[v3.2.2].

Installation failed, reverting ./composer.json to its original content.
```

# Steps to reproduce

Create a new project that includes psy/psysh at ~0.8 and drupal/console at ~1.0.
