### PR TITLE
[generate:profile] add option to specify enabled themes

### DIFF
--- a/Test/Generator/ProfileGeneratorTest.php
+++ b/Test/Generator/ProfileGeneratorTest.php
@@ -37,6 +37,7 @@ class ProfileGeneratorTest extends GeneratorTest
         $description,
         $core,
         $dependencies,
+        $themes,
         $distribution
     ) {
         $generator = new ProfileGenerator();
@@ -51,6 +52,7 @@ class ProfileGeneratorTest extends GeneratorTest
             $description,
             $core,
             $dependencies,
+            $themes,
             $distribution
         );
 

--- a/config/services/drupal-console/generate.yml
+++ b/config/services/drupal-console/generate.yml
@@ -1,7 +1,7 @@
 services:
   console.generate_module:
     class: Drupal\Console\Command\Generate\ModuleCommand
-    arguments: ['@console.module_generator', '@console.validator', '@app.root', '@console.string_converter', '@console.drupal_api', '@http_client', '@console.site']
+    arguments: ['@console.module_generator', '@console.validator', '@app.root', '@console.string_converter', '@console.drupal_api']
     tags:
        - { name: drupal.command }
   console.generate_modulefile:
@@ -141,7 +141,7 @@ services:
        - { name: drupal.command }
   console.generate_profile:
     class: Drupal\Console\Command\Generate\ProfileCommand
-    arguments: ['@console.extension_manager', '@console.profile_generator', '@console.string_converter', '@console.validator', '@app.root', '@console.site', '@http_client']
+    arguments: ['@console.extension_manager', '@console.profile_generator', '@console.string_converter', '@console.validator', '@app.root']
     tags:
        - { name: drupal.command }
   console.generate_route_subscriber:

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -214,7 +214,7 @@ class ModuleCommand extends Command
         $twigtemplate = $input->getOption('twigtemplate');
 
          // Modules Dependencies, re-factor and share with other commands
-        $dependencies = $this->validator->validateModuleDependencies($input->getOption('dependencies'));
+        $dependencies = $this->validator->validateMachineNameList($input->getOption('dependencies'));
         // Check if all module dependencies are available
         if ($dependencies) {
             $checked_dependencies = $this->checkDependencies($dependencies['success'], $io);

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -169,7 +169,8 @@ class ModuleCommand extends Command
                 'dependencies',
                 '',
                 InputOption::VALUE_OPTIONAL,
-                $this->trans('commands.generate.module.options.dependencies')
+                $this->trans('commands.generate.module.options.dependencies'),
+                ''
             )
             ->addOption(
                 'test',
@@ -210,24 +211,9 @@ class ModuleCommand extends Command
         $moduleFile = $input->getOption('module-file');
         $featuresBundle = $input->getOption('features-bundle');
         $composer = $input->getOption('composer');
+        $dependencies = $this->validator->validateExtensions($input->getOption('dependencies'), 'module', $io);
         $test = $input->getOption('test');
         $twigtemplate = $input->getOption('twigtemplate');
-
-         // Modules Dependencies, re-factor and share with other commands
-        $dependencies = $this->validator->validateMachineNameList($input->getOption('dependencies'));
-        // Check if all module dependencies are available
-        if ($dependencies) {
-            $checked_dependencies = $this->checkDependencies($dependencies['success'], $io);
-            if (!empty($checked_dependencies['no_modules'])) {
-                $io->warning(
-                    sprintf(
-                        $this->trans('commands.generate.module.warnings.module-unavailable'),
-                        implode(', ', $checked_dependencies['no_modules'])
-                    )
-                );
-            }
-            $dependencies = $dependencies['success'];
-        }
 
         $this->generator->generate(
             $module,
@@ -243,47 +229,6 @@ class ModuleCommand extends Command
             $test,
             $twigtemplate
         );
-    }
-
-    /**
-     * @param  array $dependencies
-     * @return array
-     */
-    private function checkDependencies(array $dependencies, DrupalStyle $io)
-    {
-        $this->site->loadLegacyFile('/core/modules/system/system.module');
-        $localModules = [];
-
-        $modules = system_rebuild_module_data();
-        foreach ($modules as $module_id => $module) {
-            array_push($localModules, basename($module->subpath));
-        }
-
-        $checkDependencies = [
-          'local_modules' => [],
-          'drupal_modules' => [],
-          'no_modules' => [],
-        ];
-
-        foreach ($dependencies as $module) {
-            if (in_array($module, $localModules)) {
-                $checkDependencies['local_modules'][] = $module;
-            } else {
-                try {
-                    $response = $this->httpClient->head('https://www.drupal.org/project/' . $module);
-                    $header_link = explode(';', $response->getHeader('link'));
-                    if (empty($header_link[0])) {
-                        $checkDependencies['no_modules'][] = $module;
-                    } else {
-                        $checkDependencies['drupal_modules'][] = $module;
-                    }
-                } catch (ClientException $e) {
-                    $checkDependencies['no_modules'][] = $module;
-                }
-            }
-        }
-
-        return $checkDependencies;
     }
 
     /**

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -19,9 +19,6 @@ use Drupal\Console\Utils\Validator;
 use Drupal\Console\Core\Command\Shared\CommandTrait;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Utils\DrupalApi;
-use GuzzleHttp\Client;
-use Drupal\Console\Utils\Site;
-use GuzzleHttp\Exception\ClientException;
 
 class ModuleCommand extends Command
 {
@@ -54,16 +51,6 @@ class ModuleCommand extends Command
     protected $drupalApi;
 
     /**
-     * @var Client
-     */
-    protected $httpClient;
-
-    /**
-     * @var Site
-     */
-    protected $site;
-
-    /**
      * @var string
      */
     protected $twigtemplate;
@@ -77,8 +64,6 @@ class ModuleCommand extends Command
      * @param $appRoot
      * @param StringConverter $stringConverter
      * @param DrupalApi       $drupalApi
-     * @param Client          $httpClient
-     * @param Site            $site
      * @param $twigtemplate
      */
     public function __construct(
@@ -87,8 +72,6 @@ class ModuleCommand extends Command
         $appRoot,
         StringConverter $stringConverter,
         DrupalApi $drupalApi,
-        Client $httpClient,
-        Site $site,
         $twigtemplate = null
     ) {
         $this->generator = $generator;
@@ -96,8 +79,6 @@ class ModuleCommand extends Command
         $this->appRoot = $appRoot;
         $this->stringConverter = $stringConverter;
         $this->drupalApi = $drupalApi;
-        $this->httpClient = $httpClient;
-        $this->site = $site;
         $this->twigtemplate = $twigtemplate;
         parent::__construct();
     }

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -26,13 +26,13 @@ class ModuleCommand extends Command
     use CommandTrait;
 
     /**
- * @var ModuleGenerator
-*/
+     * @var ModuleGenerator
+     */
     protected $generator;
 
     /**
- * @var Validator
-*/
+     * @var Validator
+     */
     protected $validator;
 
     /**

--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -115,6 +115,13 @@ class ProfileCommand extends Command
                 ''
             )
             ->addOption(
+                'themes',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.profile.options.themes'),
+                ''
+            )
+            ->addOption(
                 'distribution',
                 false,
                 InputOption::VALUE_OPTIONAL,
@@ -138,6 +145,7 @@ class ProfileCommand extends Command
         $description = $input->getOption('description');
         $core = $input->getOption('core');
         $dependencies = $this->validator->validateExtensions($input->getOption('dependencies'), 'module', $io);
+        $themes = $this->validator->validateExtensions($input->getOption('themes'), 'theme', $io);
         $distribution = $input->getOption('distribution');
         $profile_path = $this->appRoot . '/profiles';
 
@@ -148,6 +156,7 @@ class ProfileCommand extends Command
             $description,
             $core,
             $dependencies,
+            $themes,
             $distribution
         );
     }

--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -31,13 +31,13 @@ class ProfileCommand extends Command
     use CommandTrait;
 
     /**
- * @var Manager
-*/
+     * @var Manager
+     */
     protected $extensionManager;
 
     /**
- * @var ProfileGenerator
-*/
+     * @var ProfileGenerator
+     */
     protected $generator;
 
     /**
@@ -46,8 +46,8 @@ class ProfileCommand extends Command
     protected $stringConverter;
 
     /**
- * @var Validator
-*/
+     * @var Validator
+     */
     protected $validator;
 
     /**

--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -158,7 +158,7 @@ class ProfileCommand extends Command
         $profile_path = $this->appRoot . '/profiles';
 
         // Check if all module dependencies are available.
-        $dependencies = $this->validator->validateModuleDependencies($input->getOption('dependencies'));
+        $dependencies = $this->validator->validateMachineNameList($input->getOption('dependencies'));
         if ($dependencies) {
             $checked_dependencies = $this->checkDependencies($dependencies['success']);
             if (!empty($checked_dependencies['no_modules'])) {

--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -18,8 +18,6 @@ use Drupal\Console\Core\Command\Shared\CommandTrait;
 use Drupal\Console\Extension\Manager;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Utils\Validator;
-use Drupal\Console\Utils\Site;
-use GuzzleHttp\Client;
 
 /**
  * Class ProfileCommand
@@ -53,16 +51,6 @@ class ProfileCommand extends Command
     protected $validator;
 
     /**
-     * @var Site
-     */
-    protected $site;
-
-    /**
-     * @var Client
-     */
-    protected $httpClient;
-
-    /**
      * ProfileCommand constructor.
      *
      * @param Manager          $extensionManager
@@ -70,25 +58,19 @@ class ProfileCommand extends Command
      * @param StringConverter  $stringConverter
      * @param Validator        $validator
      * @param $appRoot
-     * @param Site             $site
-     * @param Client           $httpClient
      */
     public function __construct(
         Manager $extensionManager,
         ProfileGenerator $generator,
         StringConverter $stringConverter,
         Validator $validator,
-        $appRoot,
-        Site $site,
-        Client $httpClient
+        $appRoot
     ) {
         $this->extensionManager = $extensionManager;
         $this->generator = $generator;
         $this->stringConverter = $stringConverter;
         $this->validator = $validator;
         $this->appRoot = $appRoot;
-        $this->site = $site;
-        $this->httpClient = $httpClient;
         parent::__construct();
     }
 

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -135,6 +135,8 @@ class Manager
     {
         $this->extension = $extension;
         $this->extensions[$extension] = $this->discoverExtensions($extension);
+
+        return $this;
     }
 
     /**

--- a/src/Generator/ProfileGenerator.php
+++ b/src/Generator/ProfileGenerator.php
@@ -18,6 +18,7 @@ class ProfileGenerator extends Generator
         $description,
         $core,
         $dependencies,
+        $themes,
         $distribution
     ) {
         $dir = $profile_path . '/' . $machine_name;
@@ -57,6 +58,7 @@ class ProfileGenerator extends Generator
           'core' => $core,
           'description' => $description,
           'dependencies' => $dependencies,
+          'themes' => $themes,
           'distribution' => $distribution,
         ];
 

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -8,6 +8,8 @@
 namespace Drupal\Console\Utils;
 
 use Drupal\Console\Extension\Manager;
+use Drupal\Console\Core\Style\DrupalStyle;
+
 
 class Validator
 {
@@ -258,5 +260,32 @@ class Validator
             ->getList(true);
 
         return array_diff($moduleList, $modules);
+    }
+
+    /**
+     * @param  string $extensions_list
+     * @param  string $type
+     * @param  array $io
+     *
+     * @return array
+     */
+    public function validateExtensions(string $extensions_list, string $type, DrupalStyle $io)
+    {
+        $extensions = $this->validateMachineNameList($extensions_list);
+        // Check if all extensions are available
+        if ($extensions) {
+            $checked_extensions = $this->extensionManager->checkExtensions($extensions['success'], $type);
+            if (!empty($checked_extensions['no_extensions'])) {
+                $io->warning(
+                    sprintf(
+                        $this->trans('validator.warnings.extension-unavailable'),
+                        implode(', ', $checked_extensions['no_extensions'])
+                    )
+                );
+            }
+            $extensions = $extensions['success'];
+        }
+
+        return $extensions;
     }
 }

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -114,29 +114,29 @@ class Validator
         return $module_path;
     }
 
-    public function validateModuleDependencies($dependencies)
+    public function validateMachineNameList($list)
     {
-        $dependencies_checked = [
+        $list_checked = [
           'success' => [],
           'fail' => [],
         ];
 
-        if (empty($dependencies)) {
+        if (empty($list)) {
             return [];
         }
 
-        $dependencies = explode(',', $this->removeSpaces($dependencies));
-        foreach ($dependencies as $key => $module) {
+        $list = explode(',', $this->removeSpaces($list));
+        foreach ($list as $key => $module) {
             if (!empty($module)) {
                 if (preg_match(self::REGEX_MACHINE_NAME, $module)) {
-                    $dependencies_checked['success'][] = $module;
+                    $list_checked['success'][] = $module;
                 } else {
-                    $dependencies_checked['fail'][] = $module;
+                    $list_checked['fail'][] = $module;
                 }
             }
         }
 
-        return $dependencies_checked;
+        return $list_checked;
     }
 
     /**

--- a/templates/profile/info.yml.twig
+++ b/templates/profile/info.yml.twig
@@ -14,3 +14,10 @@ dependencies:
   - {{ dependency }}
 {% endfor %}
 {% endif %}
+{% if themes %}
+
+themes:
+{% for theme in themes %}
+  - {{ theme }}
+{% endfor %}
+{% endif %}

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@app.root', '@console.configuration_manager']
   console.extension_manager:
     class: Drupal\Console\Extension\Manager
-    arguments: ['@console.site', '@app.root']
+    arguments: ['@console.site', '@http_client', '@app.root']
   console.server:
     class: Drupal\Console\Command\ServerCommand
     arguments: ['@app.root', '@console.configuration_manager']


### PR DESCRIPTION
Refactor `checkDependencies()` first and then finally add the `--themes` option as per #3092.

@jmolivas this will require some changes in console-en:

* Remove `commands.generate.module.warnings.module-unavailable`
* Remove `commands.generate.profile.warnings.module-unavailable`
* Add `validator.warnings.extension-unavailable`
* Add `commands.generate.profile.options.themes`

Will you do that?

Thanks,
   Antonio

P.S. BTW, with vanilla 1.0.0-rc16 I was getting this error:
```
TypeError: Argument 6 passed to Drupal\Console\Command\Generate\ModuleCommand::__construct()
must be an instance of GuzzleHttp\Client, none given in
.../vendor/drupal/console/src/Command/Generate/ModuleCommand.php on line 84
```
However after applying this series the error is gone because `ModuleCommand` does not use `http_client` anymore.