### PR TITLE
[config:export] Export all config collections (#3182)

### DIFF
--- a/config/services/drupal-console/config.yml
+++ b/config/services/drupal-console/config.yml
@@ -21,7 +21,7 @@ services:
       - { name: drupal.command }
   console.config_export:
     class: Drupal\Console\Command\Config\ExportCommand
-    arguments: ['@config.manager']
+    arguments: ['@config.manager', '@config.storage']
     tags:
       - { name: drupal.command }
   console.config_export_content_type:


### PR DESCRIPTION
In particular, this includes the language.* collections provided by the config_translation module, and fixes a bug wherein config:export followed by config:import will delete translations.