### PR TITLE
[generate:command] Add required argument to ExtensionManager::getList()

### DIFF
--- a/src/Command/Shared/ExtensionTrait.php
+++ b/src/Command/Shared/ExtensionTrait.php
@@ -37,7 +37,7 @@ trait ExtensionTrait
                 ->showInstalled()
                 ->showUninstalled()
                 ->showNoCore()
-                ->getList();
+                ->getList(false);
         }
 
         if ($theme) {
@@ -45,7 +45,7 @@ trait ExtensionTrait
                 ->showInstalled()
                 ->showUninstalled()
                 ->showNoCore()
-                ->getList();
+                ->getList(false);
         }
 
         if ($profile) {
@@ -54,7 +54,7 @@ trait ExtensionTrait
                 ->showUninstalled()
                 ->showNoCore()
                 ->showCore()
-                ->getList();
+                ->getList(false);
         }
 
         $extensions = array_merge(


### PR DESCRIPTION
There is a bug inside the ExtensionTrait which is only used by the generate:command command right now. It calls ExtensionManager::getList() without an argument, resulting in an `ArgumentCountError: Too few arguments to function Drupal\Console\Extension\Manager::getList()`.

This pull request adds a parameter to the function call. Alternatively the function could provide a default parameter.

Issue: https://github.com/hechoendrupal/drupal-console/issues/3209