### PR TITLE
Added the extensionManager nedded by mou when no module is specified.

### DIFF
--- a/config/services/drupal-console/module.yml
+++ b/config/services/drupal-console/module.yml
@@ -27,7 +27,7 @@ services:
         - { name: drupal.command }
   module_uninstall:
     class: Drupal\Console\Command\Module\UninstallCommand
-    arguments: ['@console.site','@module_installer', '@console.chain_queue', '@config.factory']
+    arguments: ['@console.site','@module_installer', '@console.chain_queue', '@config.factory', '@console.extension_manager']
     tags:
       - { name: drupal.command }
   module_update:

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -8,6 +8,7 @@
 namespace Drupal\Console\Command\Module;
 
 use Drupal\Console\Core\Command\Shared\CommandTrait;
+use Drupal\Console\Extension\Manager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,6 +47,11 @@ class UninstallCommand extends Command
 */
     protected $configFactory;
 
+  /**
+   * @var Manager
+   */
+  protected $extensionManager;
+
 
     /**
      * InstallCommand constructor.
@@ -54,17 +60,20 @@ class UninstallCommand extends Command
      * @param Validator     $validator
      * @param ChainQueue    $chainQueue
      * @param ConfigFactory $configFactory
+     * @param Manager       $extensionManager
      */
     public function __construct(
         Site $site,
         ModuleInstaller $moduleInstaller,
         ChainQueue $chainQueue,
-        ConfigFactory $configFactory
+        ConfigFactory $configFactory,
+        Manager $extensionManager
     ) {
         $this->site = $site;
         $this->moduleInstaller = $moduleInstaller;
         $this->chainQueue = $chainQueue;
         $this->configFactory = $configFactory;
+        $this->extensionManager = $extensionManager;
         parent::__construct();
     }
 


### PR DESCRIPTION
- When you use "mou" without specifying tha name of the module, the command call modulesUninstallQuestion to load the list of installed module.

- modulesUninstallQuestion method in turn load the list using the extensionManager

- the extensionManager is not injected and declared in the UninstallCommand so we got a null reference exception.

**To reproduce just run "drupal mou" without specifying tha name of the module**