### PR TITLE
[template] Use short array syntax in all templates

### DIFF
--- a/templates/module/Tests/Controller/controller.php.twig
+++ b/templates/module/Tests/Controller/controller.php.twig
@@ -23,11 +23,11 @@ class {{class_name}}Test extends WebTestBase {% endblock %}
    * {@inheritdoc}
    */
   public static function getInfo() {
-    return array(
+    return [
       'name' => "{{module}} {{class_name}}'s controller functionality",
       'description' => 'Test Unit for module {{module}} and controller {{class_name}}.',
       'group' => 'Other',
-    );
+    ];
   }
 
   /**

--- a/templates/module/module.views.inc.twig
+++ b/templates/module/module.views.inc.twig
@@ -21,19 +21,19 @@ use Drupal\system\ActionConfigEntityInterface;
 function {{module}}_views_data() {
 
     $data['views']['table']['group'] = t('Custom Global');
-    $data['views']['table']['join'] = array(
+    $data['views']['table']['join'] = [
       // #global is a special flag which allows a table to appear all the time.
-      '#global' => array(),
-    );
+      '#global' => array[],
+    ];
 
 
-    $data['views']['{{ class_machine_name }}'] = array(
+    $data['views']['{{ class_machine_name }}'] = [
         'title' => t('{{ title }}'),
         'help' => t('{{ description }}'),
-        'field' => array(
+        'field' => [
             'id' => '{{ class_machine_name }}',
-        ),
-    );
+        ],
+    ];
 
     return $data;
 }

--- a/templates/module/src/Controller/entity-controller.php.twig
+++ b/templates/module/src/Controller/entity-controller.php.twig
@@ -53,7 +53,7 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
    */
   public function revisionPageTitle(${{ entity_name }}_revision) {
     ${{ entity_name }} = $this->entityManager()->getStorage('{{ entity_name }}')->loadRevision(${{ entity_name }}_revision);
-    return $this->t('Revision of %title from %date', array('%title' => ${{ entity_name }}->label(), '%date' => format_date(${{ entity_name }}->getRevisionCreationTime())));
+    return $this->t('Revision of %title from %date', ['%title' => ${{ entity_name }}->label(), '%date' => format_date(${{ entity_name }}->getRevisionCreationTime())]);
   }
 
   /**
@@ -74,12 +74,12 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
     ${{ entity_name }}_storage = $this->entityManager()->getStorage('{{ entity_name }}');
 
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => ${{ entity_name }}->label()]) : $this->t('Revisions for %title', ['%title' => ${{ entity_name }}->label()]);
-    $header = array($this->t('Revision'), $this->t('Operations'));
+    $header = [$this->t('Revision'), $this->t('Operations')];
 
     $revert_permission = (($account->hasPermission("revert all {{ label|lower }} revisions") || $account->hasPermission('administer {{ label|lower }} entities')));
     $delete_permission = (($account->hasPermission("delete all {{ label|lower }} revisions") || $account->hasPermission('administer {{ label|lower }} entities')));
 
-    $rows = array();
+    $rows = [];
 
     $vids = ${{ entity_name }}_storage->revisionIds(${{ entity_name }});
 
@@ -166,11 +166,11 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
       }
     }
 
-    $build['{{ entity_name }}_revisions_table'] = array(
+    $build['{{ entity_name }}_revisions_table'] = [
       '#theme' => 'table',
       '#rows' => $rows,
       '#header' => $header,
-    );
+    ];
 
     return $build;
   }

--- a/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
@@ -82,14 +82,14 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
    * {@inheritdoc}
    */
   public function getQuestion() {
-    return t('Are you sure you want to delete the revision from %revision-date?', array('%revision-date' => format_date($this->revision->getRevisionCreationTime())));
+    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => format_date($this->revision->getRevisionCreationTime())]);
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('entity.{{ entity_name }}.version_history', array('{{ entity_name }}' => $this->revision->id()));
+    return new Url('entity.{{ entity_name }}.version_history', ['{{ entity_name }}' => $this->revision->id()]);
   }
 
   /**
@@ -115,16 +115,16 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->{{ entity_class }}Storage->deleteRevision($this->revision->getRevisionId());
 
-    $this->logger('content')->notice('{{ label }}: deleted %title revision %revision.', array('%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()));
-    drupal_set_message(t('Revision from %revision-date of {{ label }} %title has been deleted.', array('%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label())));
+    $this->logger('content')->notice('{{ label }}: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
+    drupal_set_message(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.{{ entity_name }}.canonical',
-       array('{{ entity_name }}' => $this->revision->id())
+       ['{{ entity_name }}' => $this->revision->id()]
     );
-    if ($this->connection->query('SELECT COUNT(DISTINCT vid) FROM {{ '{'~entity_name~'_field_revision}' }} WHERE id = :id', array(':id' => $this->revision->id()))->fetchField() > 1) {
+    if ($this->connection->query('SELECT COUNT(DISTINCT vid) FROM {{ '{'~entity_name~'_field_revision}' }} WHERE id = :id', [':id' => $this->revision->id()])->fetchField() > 1) {
       $form_state->setRedirect(
         'entity.{{ entity_name }}.version_history',
-         array('{{ entity_name }}' => $this->revision->id())
+         ['{{ entity_name }}' => $this->revision->id()]
       );
     }
   }

--- a/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
@@ -87,11 +87,11 @@ class {{ entity_class }}RevisionRevertTranslationForm extends {{ entity_class }}
     $this->langcode = $langcode;
     $form = parent::buildForm($form, $form_state, ${{ entity_name }}_revision);
 
-    $form['revert_untranslated_fields'] = array(
+    $form['revert_untranslated_fields'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Revert content shared among translations'),
       '#default_value' => FALSE,
-    );
+    ];
 
     return $form;
   }

--- a/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
@@ -89,7 +89,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('entity.{{ entity_name }}.version_history', array('{{ entity_name }}' => $this->revision->id()));
+    return new Url('entity.{{ entity_name }}.version_history', ['{{ entity_name }}' => $this->revision->id()]);
   }
 
   /**
@@ -132,7 +132,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
     drupal_set_message(t('{{ label }} %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
     $form_state->setRedirect(
       'entity.{{ entity_name }}.version_history',
-      array('{{ entity_name }}' => $this->revision->id())
+      ['{{ entity_name }}' => $this->revision->id()]
     );
   }
 

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -30,12 +30,12 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
 {% if revisionable %}
 
     if (!$this->entity->isNew()) {
-      $form['new_revision'] = array(
+      $form['new_revision'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Create new revision'),
         '#default_value' => FALSE,
         '#weight' => 10,
-      );
+      ];
     }
 {% endif %}
 

--- a/templates/module/src/Entity/entity-content-with-bundle.theme_hook_suggestions.php.twig
+++ b/templates/module/src/Entity/entity-content-with-bundle.theme_hook_suggestions.php.twig
@@ -4,7 +4,7 @@
 * Implements hook_theme_suggestions_HOOK().
 */
 function {{ module }}_theme_suggestions_{{ entity_name }}(array $variables) {
-  $suggestions = array();
+  $suggestions = [];
   $entity = $variables['elements']['#{{ entity_name }}'];
   $sanitized_view_mode = strtr($variables['elements']['#view_mode'], '.', '_');
 

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -123,9 +123,9 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
    */
   public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
     parent::preCreate($storage_controller, $values);
-    $values += array(
+    $values += [
       'user_id' => \Drupal::currentUser()->id(),
-    );
+    ];
   }
 {% if revisionable %}
 
@@ -281,21 +281,21 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
       ->setTranslatable(TRUE)
-      ->setDisplayOptions('view', array(
+      ->setDisplayOptions('view', [
         'label' => 'hidden',
         'type' => 'author',
         'weight' => 0,
-      ))
-      ->setDisplayOptions('form', array(
+      ])
+      ->setDisplayOptions('form', [
         'type' => 'entity_reference_autocomplete',
         'weight' => 5,
-        'settings' => array(
+        'settings' => [
           'match_operator' => 'CONTAINS',
           'size' => '60',
           'autocomplete_type' => 'tags',
           'placeholder' => '',
-        ),
-      ))
+        ],
+      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
@@ -305,20 +305,20 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
 {% if revisionable %}
       ->setRevisionable(TRUE)
 {% endif %}
-      ->setSettings(array(
+      ->setSettings([
         'max_length' => 50,
         'text_processing' => 0,
-      ))
+      ])
       ->setDefaultValue('')
-      ->setDisplayOptions('view', array(
+      ->setDisplayOptions('view', [
         'label' => 'above',
         'type' => 'string',
         'weight' => -4,
-      ))
-      ->setDisplayOptions('form', array(
+      ])
+      ->setDisplayOptions('form', [
         'type' => 'string_textfield',
         'weight' => -4,
-      ))
+      ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 

--- a/templates/module/src/Entity/entity-content.theme.php.twig
+++ b/templates/module/src/Entity/entity-content.theme.php.twig
@@ -1,7 +1,7 @@
 {% block hook_theme %}
-  $theme['{{ entity_name }}'] = array(
+  $theme['{{ entity_name }}'] = [
     'render element' => 'elements',
     'file' => '{{ entity_name }}.page.inc',
     'template' => '{{ entity_name }}',
-  );
+  ];
 {% endblock %}

--- a/templates/module/src/entity-storage.php.twig
+++ b/templates/module/src/entity-storage.php.twig
@@ -33,7 +33,7 @@ class {{ entity_class }}Storage extends SqlContentEntityStorage implements {{ en
   public function revisionIds({{ entity_class }}Interface $entity) {
     return $this->database->query(
       'SELECT vid FROM {{ '{'~entity_name~'_revision}' }} WHERE id=:id ORDER BY vid',
-      array(':id' => $entity->id())
+      [':id' => $entity->id()]
     )->fetchCol();
   }
 
@@ -43,7 +43,7 @@ class {{ entity_class }}Storage extends SqlContentEntityStorage implements {{ en
   public function userRevisionIds(AccountInterface $account) {
     return $this->database->query(
       'SELECT vid FROM {{ '{'~entity_name~'_field_revision}' }} WHERE uid = :uid ORDER BY vid',
-      array(':uid' => $account->id())
+      [':uid' => $account->id()]
     )->fetchCol();
   }
 
@@ -51,7 +51,7 @@ class {{ entity_class }}Storage extends SqlContentEntityStorage implements {{ en
    * {@inheritdoc}
    */
   public function countDefaultLanguageRevisions({{ entity_class }}Interface $entity) {
-    return $this->database->query('SELECT COUNT(*) FROM {{ '{'~entity_name~'_field_revision}' }} WHERE id = :id AND default_langcode = 1', array(':id' => $entity->id()))
+    return $this->database->query('SELECT COUNT(*) FROM {{ '{'~entity_name~'_field_revision}' }} WHERE id = :id AND default_langcode = 1', [':id' => $entity->id()])
       ->fetchField();
   }
 
@@ -60,7 +60,7 @@ class {{ entity_class }}Storage extends SqlContentEntityStorage implements {{ en
    */
   public function clearRevisionsLanguage(LanguageInterface $language) {
     return $this->database->update('{{ entity_name }}_revision')
-      ->fields(array('langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED))
+      ->fields(['langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED])
       ->condition('langcode', $language->getId())
       ->execute();
   }

--- a/templates/module/src/listbuilder-entity-content.php.twig
+++ b/templates/module/src/listbuilder-entity-content.php.twig
@@ -45,9 +45,9 @@ class {{ entity_class }}ListBuilder extends EntityListBuilder {% endblock %}
     $row['name'] = $this->l(
       $entity->label(),
       new Url(
-        'entity.{{ entity_name }}.edit_form', array(
+        'entity.{{ entity_name }}.edit_form', [
           '{{ entity_name }}' => $entity->id(),
-        )
+        ]
       )
     );
     return $row + parent::buildRow($entity);

--- a/templates/module/src/yaml-plugin-manager.php.twig
+++ b/templates/module/src/yaml-plugin-manager.php.twig
@@ -28,11 +28,11 @@ class {{ plugin_class }}Manager extends DefaultPluginManager implements {{ plugi
    *
    * @var array
    */
-  protected $defaults = array(
+  protected $defaults = [
     // Add required and optional plugin properties.
     'id' => '',
     'label' => '',
-  );
+  ];
 
   /**
    * Constructs a {{ plugin_class }}Manager object.
@@ -45,7 +45,7 @@ class {{ plugin_class }}Manager extends DefaultPluginManager implements {{ plugi
   public function __construct(ModuleHandlerInterface $module_handler, CacheBackendInterface $cache_backend) {
     // Add more services as required.
     $this->moduleHandler = $module_handler;
-    $this->setCacheBackend($cache_backend, '{{ plugin_name }}', array('{{ plugin_name }}'));
+    $this->setCacheBackend($cache_backend, '{{ plugin_name }}', ['{{ plugin_name }}']);
   }
 
   /**


### PR DESCRIPTION
Pull request for #3229 

### Problem/Motivation
Currently the templates in Drupal Console use a combination of the short and long array syntax. Sometimes, different syntaxes are even used in the same file. For consistency, one syntax should be used across all templates. 

Short syntax makes the most sense as the Drupal core contributors have already decided to switch to short syntax for their coding standards and, as of 8.3, all of core's code has been switched to the short syntax: https://www.drupal.org/node/2776975