### PR TITLE
[site:install] Register missing service

### DIFF
--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -25,3 +25,5 @@ services:
     arguments: ['@app.root']
     tags:
       - { name: drupal.command }
+  http_client:
+    class: GuzzleHttp\Client


### PR DESCRIPTION
The http_client service is missing, so the site:install command doen't work