### PR TITLE
Remove duplicated getType() from generated content entities

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -152,15 +152,6 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
   }
 {% endif %}
 
-{% if bundle_entity_type %}
-  /**
-   * {@inheritdoc}
-   */
-  public function getType() {
-    return $this->bundle();
-  }
-
-{% endif %}
   /**
    * {@inheritdoc}
    */

--- a/templates/module/src/Entity/interface-entity-content.php.twig
+++ b/templates/module/src/Entity/interface-entity-content.php.twig
@@ -31,16 +31,6 @@ interface {{ entity_class }}Interface extends {% if revisionable %}RevisionableI
 {% block class_methods %}
   // Add get/set methods for your configuration properties here.
 
-{% if bundle_entity_type %}
-  /**
-   * Gets the {{ label }} type.
-   *
-   * @return string
-   *   The {{ label }} type.
-   */
-  public function getType();
-
-{% endif %}
   /**
    * Gets the {{ label }} name.
    *


### PR DESCRIPTION
Currently when a content entity is generated that supports bundles, this piece of code is generated in it:

```
/**
 * {@inheritdoc}
 */
public function getType() {
  return $this->bundle();
}
```

This getter is duplicating `EntityInterface::bundle()` which is the standard way of getting the bundle from any entity.

Having this `getType()` available only on entities generated by Drupal Console is confusing, since it is missing from core entities. It also doesn't serve any purpose, it is just duplicating existing functionality.