### PR TITLE
Leverage methods and base field definitions from RevisionLogEntityTrait

### DIFF
--- a/templates/module/src/Controller/entity-controller.php.twig
+++ b/templates/module/src/Controller/entity-controller.php.twig
@@ -97,7 +97,7 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
         ];
 
         // Use revision link to link to revisions that are not active.
-        $date = \Drupal::service('date.formatter')->format($revision->revision_timestamp->value, 'short');
+        $date = \Drupal::service('date.formatter')->format($revision->getRevisionCreationTime(), 'short');
         if ($vid != ${{ entity_name }}->getRevisionId()) {
           $link = $this->l($date, new Url('entity.{{ entity_name }}.revision', ['{{ entity_name }}' => ${{ entity_name }}->id(), '{{ entity_name }}_revision' => $vid]));
         }
@@ -113,7 +113,7 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
             '#context' => [
               'date' => $link,
               'username' => \Drupal::service('renderer')->renderPlain($username),
-              'message' => ['#markup' => $revision->revision_log_message->value, '#allowed_tags' => Xss::getHtmlTagList()],
+              'message' => ['#markup' => $revision->getRevisionLogMessage(), '#allowed_tags' => Xss::getHtmlTagList()],
             ],
           ],
         ];

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -235,38 +235,6 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
     $this->set('status', $published ? TRUE : FALSE);
     return $this;
   }
-{% if revisionable %}
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getRevisionCreationTime() {
-    return $this->get('revision_timestamp')->value;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setRevisionCreationTime($timestamp) {
-    $this->set('revision_timestamp', $timestamp);
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getRevisionUser() {
-    return $this->get('revision_uid')->entity;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setRevisionUserId($uid) {
-    $this->set('revision_uid', $uid);
-    return $this;
-  }
-{% endif %}
 
   /**
    * {@inheritdoc}
@@ -337,21 +305,6 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
     $fields['changed'] = BaseFieldDefinition::create('changed')
       ->setLabel(t('Changed'))
       ->setDescription(t('The time that the entity was last edited.'));
-{% if revisionable %}
-
-    $fields['revision_timestamp'] = BaseFieldDefinition::create('created')
-      ->setLabel(t('Revision timestamp'))
-      ->setDescription(t('The time that the current revision was created.'))
-      ->setQueryable(FALSE)
-      ->setRevisionable(TRUE);
-
-    $fields['revision_uid'] = BaseFieldDefinition::create('entity_reference')
-      ->setLabel(t('Revision user ID'))
-      ->setDescription(t('The user ID of the author of the current revision.'))
-      ->setSetting('target_type', 'user')
-      ->setQueryable(FALSE)
-      ->setRevisionable(TRUE);
-{% endif %}
 {% if revisionable and is_translatable %}
 
     $fields['revision_translation_affected'] = BaseFieldDefinition::create('boolean')


### PR DESCRIPTION
Currently when generating revisionable content entities we are duplicating a number of methods from `RevisionableContentEntityBase`. This class provides the `RevisionLogEntityTrait` which already contains the following methods so we do not need to duplicate them:

* `getRevisionCreationTime()`
* `setRevisionCreationTime()`
* `getRevisionUser()`
* `setRevisionUser()`
* `getRevisionUserId()`
* `setRevisionUserId()`

Additionally, it already defines base field definitions regarding which are duplicated by us but named differently. This causes duplicate field definitions to be used for these entities:

* `revision_created` (duplicated as `revision_timestamp`)
* `revision_user` (duplicated as `revision_uid`)

It looks like our current implementation is based on that of the `Node` entity which predates the `RevisionLogEntityTrait` which was added to 8.2.x. Even today the `Node` entity is not extending `RevisionableContentEntityBase` because of backwards compatibility reasons.