### PR TITLE
Improve docblocks for generated constructors

### DIFF
--- a/templates/module/src/Command/command.php.twig
+++ b/templates/module/src/Command/command.php.twig
@@ -37,7 +37,7 @@ class {{ class_name }} extends Command {% endblock %}
 {% if services is not empty %}
 
   /**
-   * {@inheritdoc}
+   * Constructs a new {{ class_name }} object.
    */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
 {{ serviceClassInitialization(services) }}

--- a/templates/module/src/Controller/controller.php.twig
+++ b/templates/module/src/Controller/controller.php.twig
@@ -25,7 +25,7 @@ class {{ class_name }} extends ControllerBase {% endblock %}
 {% if services is not empty %}
 
   /**
-   * {@inheritdoc}
+   * Constructs a new {{ class_name }} object.
    */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
 {{ serviceClassInitialization(services) }}

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -26,6 +26,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class {{ class_name }} extends ConfigFormBase {% endblock %}
 {% block class_construct %}
 {% if services is not empty %}
+  /**
+   * Constructs a new {{ class_name }} object.
+   */
   public function __construct(
     ConfigFactoryInterface $config_factory,
       {{ servicesAsParameters(services)|join(',\n    ') }}

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -25,6 +25,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class {{ class_name }} extends FormBase {% endblock %}
 {% block class_construct %}
 {% if services is not empty %}
+  /**
+   * Constructs a new {{ class_name }} object.
+   */
   public function __construct(
     {{ servicesAsParameters(services)|join(',\n    ') }}
   ) {

--- a/templates/module/src/Plugin/Block/block.php.twig
+++ b/templates/module/src/Plugin/Block/block.php.twig
@@ -32,7 +32,7 @@ class {{class_name}} extends BlockBase {% if services is not empty %}implements 
 {% block class_construct %}
 {% if services is not empty %}
   /**
-   * Construct.
+   * Constructs a new {{class_name}} object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.

--- a/templates/module/src/Plugin/Condition/condition.php.twig
+++ b/templates/module/src/Plugin/Condition/condition.php.twig
@@ -42,7 +42,7 @@ public static function create(ContainerInterface $container, array $configuratio
 }
 
 /**
- * Creates a new ExampleCondition instance.
+ * Creates a new {{ class_name }} object.
  *
  * @param array $configuration
  *   The plugin configuration, i.e. an array with configuration values keyed

--- a/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
+++ b/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
@@ -58,7 +58,7 @@ class {{ class_name }} extends ImageFormatterBase implements ContainerFactoryPlu
  protected $imageStyleStorage;
 
 /**
- * Constructs an ImageFormatter object.
+ * Constructs a new {{ class_name }} object.
  *
  * @param string $plugin_id
  *   The plugin_id for the formatter.

--- a/templates/module/src/Plugin/Mail/mail.php.twig
+++ b/templates/module/src/Plugin/Mail/mail.php.twig
@@ -31,7 +31,7 @@ class {{class_name}} extends PhpMail {% if services is not empty %}implements Co
 {% block class_construct %}
 {% if services is not empty %}
   /**
-   * Construct.
+   * Constructs a new {{class_name}} object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.

--- a/templates/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/templates/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -43,7 +43,7 @@ class {{ class_name }} extends ResourceBase {% endblock %}
 {% block class_construct %}
 
   /**
-   * Constructs a Drupal\rest\Plugin\ResourceBase object.
+   * Constructs a new {{ class_name }} object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.

--- a/templates/module/src/Plugin/skeleton.php.twig
+++ b/templates/module/src/Plugin/skeleton.php.twig
@@ -39,7 +39,7 @@ class {{class_name}} implements {% if plugin_interface is not empty %} {{ plugin
 {% block class_construct %}
 {% if services is not empty %}
   /**
-   * Construct.
+   * Constructs a new {{class_name}} object.
    *
    * @param array $configuration
    *   A configuration array containing information about the plugin instance.

--- a/templates/module/src/TwigExtension/twig-extension.php.twig
+++ b/templates/module/src/TwigExtension/twig-extension.php.twig
@@ -36,7 +36,7 @@ class {{ class }} extends \Twig_Extension {% endblock %}
     {% if services|length > 1 %}
 
    /**
-    * Constructor.
+    * Constructs a new {{ class }} object.
     */
     public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
         parent::__construct($renderer);

--- a/templates/module/src/cache-context.php.twig
+++ b/templates/module/src/cache-context.php.twig
@@ -24,8 +24,8 @@ class {{ class }} implements CacheContextInterface {% endblock %}
 {% block class_construct %}
 
   /**
-  * Constructor.
-  */
+   * Constructs a new {{ class }} object.
+   */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
   {{ serviceClassInitialization(services) }}
   }

--- a/templates/module/src/event-subscriber.php.twig
+++ b/templates/module/src/event-subscriber.php.twig
@@ -24,7 +24,7 @@ class {{ class }} implements EventSubscriberInterface {% endblock %}
 {% block class_construct %}
 
   /**
-   * Constructor.
+   * Constructs a new {{ class }} object.
    */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
 {{ serviceClassInitialization(services) }}

--- a/templates/module/src/plugin-type-annotation-manager.php.twig
+++ b/templates/module/src/plugin-type-annotation-manager.php.twig
@@ -22,7 +22,7 @@ class {{ class_name }}Manager extends DefaultPluginManager {% endblock %}
 {% block class_methods %}
 
   /**
-   * Constructor for {{ class_name }}Manager objects.
+   * Constructs a new {{ class_name }}Manager object.
    *
    * @param \Traversable $namespaces
    *   An object that implements \Traversable which contains the root paths

--- a/templates/module/src/service.php.twig
+++ b/templates/module/src/service.php.twig
@@ -16,7 +16,7 @@ namespace Drupal\{{module}};{% endblock %}
 class {{ class }}{% if(interface is defined and interface) %} implements {{ interface }}{% endif %} {% endblock %}
 {% block class_construct %}
   /**
-   * Constructor.
+   * Constructs a new {{ class }} object.
    */
   public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
 {{ serviceClassInitialization(services) }}

--- a/templates/module/src/yaml-plugin-manager.php.twig
+++ b/templates/module/src/yaml-plugin-manager.php.twig
@@ -35,7 +35,7 @@ class {{ plugin_class }}Manager extends DefaultPluginManager implements {{ plugi
   ];
 
   /**
-   * Constructs a {{ plugin_class }}Manager object.
+   * Constructs a new {{ plugin_class }}Manager object.
    *
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.


### PR DESCRIPTION
When generating classes the documentation of the constructors is often missing or not according to documentation standards. The most typical phrase that is used in core is:

```
/**
 * Constructs an ImageFormatter object.
 */
```

but since we have to use either 'a' or 'an' depending on whether the class name starts with a vowel, I have opted for the following wording to avoid complexity:

```
/**
 * Constructs a new ImageFormatter object.
 */
```

This will be grammatically correct regardless of the naming of the class.