### PR TITLE
Use short array syntax for generated options

### DIFF
--- a/src/Command/Shared/FormTrait.php
+++ b/src/Command/Shared/FormTrait.php
@@ -126,7 +126,7 @@ trait FormTrait
                         $input_options_output[$key] = "'$value' => \$this->t('".$value."')";
                     }
 
-                    $input_options = 'array('.implode(', ', $input_options_output).')';
+                    $input_options = '['.implode(', ', $input_options_output).']';
                 }
 
                 // Description for input


### PR DESCRIPTION
When generating a form the resulting code is formatted with the short array syntax everywhere, but the options for a `select` form field are still using the old syntax:

```
    $form['category'] = [
      '#type' => 'select',
      '#title' => $this->t('Category'),
      '#options' => array('Technical problem / bug report' => $this->t('Technical problem / bug report')),
      '#size' => 5,
    ];
```

This PR ensures that short array syntax is also used for the select options.