### PR TITLE
Use @MigrateProcessPlugin in generate:plugin:migrate:process command

### DIFF
--- a/templates/module/src/Plugin/migrate/process/process.php.twig
+++ b/templates/module/src/Plugin/migrate/process/process.php.twig
@@ -18,7 +18,7 @@ use Drupal\migrate\Row;
 /**
  * Provides a '{{class_name}}' migrate process plugin.
  *
- * @MigrateProcess(
+ * @MigrateProcessPlugin(
  *  id = "{{plugin_id}}"
  * )
  */


### PR DESCRIPTION
I used `generate:plugin:migrate:process` to create a migration process plugin the other day, and my plugin was never called. Comparing with other migration process plugins, I saw that the annotation should be `@MigrateProcessPlugin` instead of `@MigrateProcess`. Making this change in my generated code made my plugin start working.