### PR TITLE
Use BTB instead of WTB

### DIFF
--- a/src/Generator/ModuleGenerator.php
+++ b/src/Generator/ModuleGenerator.php
@@ -117,7 +117,7 @@ class ModuleGenerator extends Generator
         if ($test) {
             $this->renderFile(
                 'module/src/Tests/load-test.php.twig',
-                $dir . '/src/Tests/' . 'LoadTest.php',
+                $dir . '/tests/src/Functional/' . 'LoadTest.php',
                 $parameters
             );
         }

--- a/templates/module/src/Tests/load-test.php.twig
+++ b/templates/module/src/Tests/load-test.php.twig
@@ -1,16 +1,16 @@
 {% extends "base/class.php.twig" %}
 
 {% block file_path %}
-\Drupal\{{ machine_name }}\Tests\LoadTest
+\Drupal\Tests\{{ machine_name }}\Functional\LoadTest
 {% endblock %}
 
 {% block namespace_class %}
-namespace Drupal\{{ machine_name }}\Tests;
+namespace Drupal\Tests\{{ machine_name }}\Functional;
 {% endblock %}
 
 {% block use_class %}
 use Drupal\Core\Url;
-use Drupal\simpletest\WebTestBase;
+use Drupal\Tests\BrowserTestBase;
 {% endblock %}
 
 {% block class_declaration %}
@@ -19,7 +19,7 @@ use Drupal\simpletest\WebTestBase;
  *
  * @group {{ machine_name }}
  */
-class LoadTest extends WebTestBase{% endblock %}
+class LoadTest extends BrowserTestBase {% endblock %}
 {% block class_methods %}
   /**
    * Modules to enable.


### PR DESCRIPTION
Hi! 

I owe you this for a few months now, sorry! 

Ok,   WebTestBase will be deprecated in the following months. 
https://www.drupal.org/node/2847678
https://www.drupal.org/node/2735005
https://www.drupal.org/node/2851541

Let's help with this change making the DrupalConsole use BTB instead of WTB for any  new generated module. 

Regards.