### PR TITLE
[console] Standardize the second argument of Command::addOption().

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -63,17 +63,17 @@ class ExportCommand extends Command
             )
             ->addOption(
                 'tar',
-                false,
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.arguments.tar')
             )->addOption(
                 'remove-uuid',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.remove-uuid')
             )->addOption(
                 'remove-config-hash',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.remove-config-hash')
             );

--- a/src/Command/Config/ExportContentTypeCommand.php
+++ b/src/Command/Config/ExportContentTypeCommand.php
@@ -69,14 +69,14 @@ class ExportContentTypeCommand extends Command
         $this
             ->setName('config:export:content:type')
             ->setDescription($this->trans('commands.config.export.content.type.description'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addArgument(
                 'content-type',
                 InputArgument::REQUIRED,
                 $this->trans('commands.config.export.content.type.arguments.content-type')
             )->addOption(
                 'optional-config',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.export.content.type.options.optional-config')
             );

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -66,37 +66,37 @@ class ExportSingleCommand extends Command
             ->setDescription($this->trans('commands.config.export.single.description'))
             ->addOption(
                 'name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.config.export.single.options.name')
             )->addOption(
                 'directory',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.export.arguments.directory')
             )->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.common.options.module')
             )->addOption(
                 'include-dependencies',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.include-dependencies')
             )->addOption(
                 'optional',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.optional')
             )->addOption(
                 'remove-uuid',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.remove-uuid')
             )->addOption(
                 'remove-config-hash',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.export.single.options.remove-config-hash')
             );

--- a/src/Command/Config/ExportViewCommand.php
+++ b/src/Command/Config/ExportViewCommand.php
@@ -69,7 +69,7 @@ class ExportViewCommand extends Command
             ->setName('config:export:view')
             ->setDescription($this->trans('commands.config.export.view.description'))
             ->addOption(
-                'module', '',
+                'module', null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
@@ -80,13 +80,13 @@ class ExportViewCommand extends Command
             )
             ->addOption(
                 'optional-config',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.export.view.options.optional-config')
             )
             ->addOption(
                 'include-module-dependencies',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.export.view.options.include-module-dependencies')
             );

--- a/src/Command/Config/ImportCommand.php
+++ b/src/Command/Config/ImportCommand.php
@@ -70,7 +70,7 @@ class ImportCommand extends Command
             )
             ->addOption(
                 'remove-files',
-                false,
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.config.import.options.remove-files')
             );

--- a/src/Command/Config/ImportSingleCommand.php
+++ b/src/Command/Config/ImportSingleCommand.php
@@ -70,7 +70,7 @@ class ImportSingleCommand extends Command
                 $this->trans('commands.config.import.single.options.file')
             )->addOption(
                 'directory',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.config.import.arguments.directory')
             );

--- a/src/Command/Database/AddCommand.php
+++ b/src/Command/Database/AddCommand.php
@@ -50,43 +50,43 @@ class AddCommand extends Command
             ->setDescription($this->trans('commands.database.add.description'))
             ->addOption(
                 'database',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.database.add.options.database')
             )
             ->addOption(
                 'username',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.database.add.options.username')
             )
             ->addOption(
                 'password',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.database.add.options.password')
             )
             ->addOption(
                 'prefix',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.add.options.prefix')
             )
             ->addOption(
                 'host',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.add.options.host')
             )
             ->addOption(
                 'port',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.add.options.port')
             )
             ->addOption(
                 'driver',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.add.options.driver')
             )

--- a/src/Command/Database/DatabaseLogBase.php
+++ b/src/Command/Database/DatabaseLogBase.php
@@ -108,19 +108,19 @@ abstract class DatabaseLogBase extends Command
         $this
             ->addOption(
                 'type',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.common.options.type')
             )
             ->addOption(
                 'severity',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.common.options.severity')
             )
             ->addOption(
                 'user-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.common.options.user-id')
             );

--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -66,7 +66,7 @@ class DumpCommand extends Command
             )
             ->addOption(
                 'gz',
-                false,
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.database.dump.options.gz')
             )

--- a/src/Command/Database/LogClearCommand.php
+++ b/src/Command/Database/LogClearCommand.php
@@ -52,19 +52,19 @@ class LogClearCommand extends Command
             )
             ->addOption(
                 'type',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.clear.options.type')
             )
             ->addOption(
                 'severity',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.clear.options.severity')
             )
             ->addOption(
                 'user-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.log.clear.options.user-id')
             );

--- a/src/Command/Database/LogDebugCommand.php
+++ b/src/Command/Database/LogDebugCommand.php
@@ -65,7 +65,7 @@ class LogDebugCommand extends DatabaseLogBase
             )
             ->addOption(
                 'asc',
-                false,
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.database.log.debug.options.asc')
             )

--- a/src/Command/Database/QueryCommand.php
+++ b/src/Command/Database/QueryCommand.php
@@ -46,13 +46,13 @@ class QueryCommand extends Command
                 $this->trans('commands.database.query.arguments.database'),
                 'default'
             )
-            ->addOption('quick', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.quick'))
-            ->addOption('debug', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.debug'))
-            ->addOption('html', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.html'))
-            ->addOption('xml', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.xml'))
-            ->addOption('raw', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.raw'))
-            ->addOption('vertical', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.vertical'))
-            ->addOption('batch', '', InputOption::VALUE_NONE, $this->trans('commands.database.query.options.batch'))
+            ->addOption('quick', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.quick'))
+            ->addOption('debug', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.debug'))
+            ->addOption('html', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.html'))
+            ->addOption('xml', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.xml'))
+            ->addOption('raw', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.raw'))
+            ->addOption('vertical', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.vertical'))
+            ->addOption('batch', null, InputOption::VALUE_NONE, $this->trans('commands.database.query.options.batch'))
 
             ->setHelp($this->trans('commands.database.query.help'));
     }

--- a/src/Command/Database/TableDebugCommand.php
+++ b/src/Command/Database/TableDebugCommand.php
@@ -63,7 +63,7 @@ class TableDebugCommand extends Command
             ->setDescription($this->trans('commands.database.table.debug.description'))
             ->addOption(
                 'database',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.table.debug.options.database'),
                 'default'

--- a/src/Command/Develop/TranslationPendingCommand.php
+++ b/src/Command/Develop/TranslationPendingCommand.php
@@ -77,7 +77,7 @@ class TranslationPendingCommand extends Command
             )
             ->addOption(
                 'file',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.translation.pending.options.file'),
                 null

--- a/src/Command/Develop/TranslationStatsCommand.php
+++ b/src/Command/Develop/TranslationStatsCommand.php
@@ -85,7 +85,7 @@ class TranslationStatsCommand extends Command
             )
             ->addOption(
                 'format',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.translation.stats.options.format'),
                 'table'

--- a/src/Command/Develop/TranslationSyncCommand.php
+++ b/src/Command/Develop/TranslationSyncCommand.php
@@ -64,7 +64,7 @@ class TranslationSyncCommand extends Command
             )
             ->addOption(
                 'file',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.translation.stats.options.file'),
                 null

--- a/src/Command/Features/ImportCommand.php
+++ b/src/Command/Features/ImportCommand.php
@@ -41,7 +41,7 @@ class ImportCommand extends Command
             ->setDescription($this->trans('commands.features.import.description'))
             ->addOption(
                 'bundle',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.features.import.options.bundle')
             )

--- a/src/Command/Generate/AuthenticationProviderCommand.php
+++ b/src/Command/Generate/AuthenticationProviderCommand.php
@@ -69,16 +69,16 @@ class AuthenticationProviderCommand extends Command
             ->setName('generate:authentication:provider')
             ->setDescription($this->trans('commands.generate.authentication.provider.description'))
             ->setHelp($this->trans('commands.generate.authentication.provider.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.authentication.provider.options.class')
             )
             ->addOption(
                 'provider-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.authentication.provider.options.provider-id')
             );

--- a/src/Command/Generate/BreakPointCommand.php
+++ b/src/Command/Generate/BreakPointCommand.php
@@ -97,13 +97,13 @@ class BreakPointCommand extends Command
             ->setHelp($this->trans('commands.generate.breakpoint.help'))
             ->addOption(
                 'theme',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.breakpoint.options.theme')
             )
             ->addOption(
                 'breakpoints',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.breakpoint.options.breakpoints')
             );

--- a/src/Command/Generate/CommandCommand.php
+++ b/src/Command/Generate/CommandCommand.php
@@ -91,37 +91,37 @@ class CommandCommand extends Command
             ->setHelp($this->trans('commands.generate.command.help'))
             ->addOption(
                 'extension',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.extension')
             )
             ->addOption(
                 'extension-type',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.extension-type')
             )
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.command.options.class')
             )
             ->addOption(
                 'name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.command.options.name')
             )
             ->addOption(
                 'container-aware',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.generate.command.options.container-aware')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             );

--- a/src/Command/Generate/ControllerCommand.php
+++ b/src/Command/Generate/ControllerCommand.php
@@ -97,31 +97,31 @@ class ControllerCommand extends Command
             ->setHelp($this->trans('commands.generate.controller.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.controller.options.class')
             )
             ->addOption(
                 'routes',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.generate.controller.options.routes')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             )
             ->addOption(
                 'test',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.generate.controller.options.test')
             );

--- a/src/Command/Generate/EntityBundleCommand.php
+++ b/src/Command/Generate/EntityBundleCommand.php
@@ -69,16 +69,16 @@ class EntityBundleCommand extends Command
             ->setName('generate:entity:bundle')
             ->setDescription($this->trans('commands.generate.entity.bundle.description'))
             ->setHelp($this->trans('commands.generate.entity.bundle.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'bundle-name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.entity.bundle.options.bundle-name')
             )
             ->addOption(
                 'bundle-title',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.entity.bundle.options.bundle-title')
             );

--- a/src/Command/Generate/FormAlterCommand.php
+++ b/src/Command/Generate/FormAlterCommand.php
@@ -138,19 +138,19 @@ class FormAlterCommand extends Command
             ->setHelp($this->trans('commands.generate.form.alter.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'form-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.alter.options.form-id')
             )
             ->addOption(
                 'inputs',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.inputs')
             );

--- a/src/Command/Generate/FormCommand.php
+++ b/src/Command/Generate/FormCommand.php
@@ -122,67 +122,67 @@ abstract class FormCommand extends Command
             )
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.class')
             )
             ->addOption(
                 'form-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.form-id')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             )
             ->addOption(
                 'config-file',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.generate.form.options.config-file')
             )
             ->addOption(
                 'inputs',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.common.options.inputs')
             )
             ->addOption(
                 'path',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.path')
             )
             ->addOption(
                 'menu_link_gen',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.menu_link_gen')
             )
             ->addOption(
                 'menu_link_title',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.menu_link_title')
             )
             ->addOption(
                 'menu_parent',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.menu_parent')
             )
             ->addOption(
                 'menu_link_desc',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.menu_link_desc')
             );

--- a/src/Command/Generate/HelpCommand.php
+++ b/src/Command/Generate/HelpCommand.php
@@ -76,13 +76,13 @@ class HelpCommand extends Command
             ->setHelp($this->trans('commands.generate.help.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.description')
             );

--- a/src/Command/Generate/ModuleCommand.php
+++ b/src/Command/Generate/ModuleCommand.php
@@ -94,74 +94,74 @@ class ModuleCommand extends Command
             ->setHelp($this->trans('commands.generate.module.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.module.options.module')
             )
             ->addOption(
                 'machine-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.module.options.machine-name')
             )
             ->addOption(
                 'module-path',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.module.options.module-path')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.description')
             )
             ->addOption(
                 'core',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.core')
             )
             ->addOption(
                 'package',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.package')
             )
             ->addOption(
                 'module-file',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.generate.module.options.module-file')
             )
             ->addOption(
                 'features-bundle',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.module.options.features-bundle')
             )
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.generate.module.options.composer')
             )
             ->addOption(
                 'dependencies',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.dependencies'),
                 ''
             )
             ->addOption(
                 'test',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.test')
             )
             ->addOption(
                 'twigtemplate',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.module.options.twigtemplate')
             );

--- a/src/Command/Generate/ModuleFileCommand.php
+++ b/src/Command/Generate/ModuleFileCommand.php
@@ -64,7 +64,7 @@ class ModuleFileCommand extends Command
             ->setName('generate:module:file')
             ->setDescription($this->trans('commands.generate.module.file.description'))
             ->setHelp($this->trans('commands.generate.module.file.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'));
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'));
     }
 
     /**

--- a/src/Command/Generate/PermissionCommand.php
+++ b/src/Command/Generate/PermissionCommand.php
@@ -70,13 +70,13 @@ class PermissionCommand extends Command
             ->setHelp($this->trans('commands.generate.permission.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'permissions',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.common.options.permissions')
             );

--- a/src/Command/Generate/PluginBlockCommand.php
+++ b/src/Command/Generate/PluginBlockCommand.php
@@ -113,40 +113,40 @@ class PluginBlockCommand extends Command
             ->setName('generate:plugin:block')
             ->setDescription($this->trans('commands.generate.plugin.block.description'))
             ->setHelp($this->trans('commands.generate.plugin.block.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.block.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.block.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.block.options.plugin-id')
             )
             ->addOption(
                 'theme-region',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.block.options.theme-region')
             )
             ->addOption(
                 'inputs',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.inputs')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             );

--- a/src/Command/Generate/PluginCKEditorButtonCommand.php
+++ b/src/Command/Generate/PluginCKEditorButtonCommand.php
@@ -78,37 +78,37 @@ class PluginCKEditorButtonCommand extends Command
             ->setHelp($this->trans('commands.generate.plugin.ckeditorbutton.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.ckeditorbutton.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.ckeditorbutton.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.ckeditorbutton.options.plugin-id')
             )
             ->addOption(
                 'button-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.ckeditorbutton.options.button-name')
             )
             ->addOption(
                 'button-icon-path',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.ckeditorbutton.options.button-icon-path')
             );

--- a/src/Command/Generate/PluginConditionCommand.php
+++ b/src/Command/Generate/PluginConditionCommand.php
@@ -83,40 +83,40 @@ class PluginConditionCommand extends Command
             ->setName('generate:plugin:condition')
             ->setDescription($this->trans('commands.generate.plugin.condition.description'))
             ->setHelp($this->trans('commands.generate.plugin.condition.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.condition.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.condition.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.condition.options.plugin-id')
             )
             ->addOption(
                 'context-definition-id',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.condition.options.context-definition-id')
             )
             ->addOption(
                 'context-definition-label',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.condition.options.context-definition-label')
             )
             ->addOption(
                 'context-definition-required',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.condition.options.context-definition-required')
             );

--- a/src/Command/Generate/PluginFieldCommand.php
+++ b/src/Command/Generate/PluginFieldCommand.php
@@ -65,82 +65,82 @@ class PluginFieldCommand extends Command
             ->setName('generate:plugin:field')
             ->setDescription($this->trans('commands.generate.plugin.field.description'))
             ->setHelp($this->trans('commands.generate.plugin.field.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'type-class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.field.options.type-class')
             )
             ->addOption(
                 'type-label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.type-label')
             )
             ->addOption(
                 'type-plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.type-plugin-id')
             )
             ->addOption(
                 'type-description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.type-type-description')
             )
             ->addOption(
                 'formatter-class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.field.options.class')
             )
             ->addOption(
                 'formatter-label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.formatter-label')
             )
             ->addOption(
                 'formatter-plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.formatter-plugin-id')
             )
             ->addOption(
                 'widget-class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.field.options.formatter-class')
             )
             ->addOption(
                 'widget-label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.widget-label')
             )
             ->addOption(
                 'widget-plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.widget-plugin-id')
             )
             ->addOption(
                 'field-type',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.field-type')
             )
             ->addOption(
                 'default-widget',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.default-widget')
             )
             ->addOption(
                 'default-formatter',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.field.options.default-formatter')
             );

--- a/src/Command/Generate/PluginFieldFormatterCommand.php
+++ b/src/Command/Generate/PluginFieldFormatterCommand.php
@@ -88,28 +88,28 @@ class PluginFieldFormatterCommand extends Command
             ->setName('generate:plugin:fieldformatter')
             ->setDescription($this->trans('commands.generate.plugin.fieldformatter.description'))
             ->setHelp($this->trans('commands.generate.plugin.fieldformatter.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.fieldformatter.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldformatter.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldformatter.options.plugin-id')
             )
             ->addOption(
                 'field-type',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldformatter.options.field-type')
             );

--- a/src/Command/Generate/PluginFieldTypeCommand.php
+++ b/src/Command/Generate/PluginFieldTypeCommand.php
@@ -80,40 +80,40 @@ class PluginFieldTypeCommand extends Command
             ->setName('generate:plugin:fieldtype')
             ->setDescription($this->trans('commands.generate.plugin.fieldtype.description'))
             ->setHelp($this->trans('commands.generate.plugin.fieldtype.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.fieldtype.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldtype.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldtype.options.plugin-id')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldtype.options.description')
             )
             ->addOption(
                 'default-widget',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldtype.options.default-widget')
             )
             ->addOption(
                 'default-formatter',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldtype.options.default-formatter')
             );

--- a/src/Command/Generate/PluginFieldWidgetCommand.php
+++ b/src/Command/Generate/PluginFieldWidgetCommand.php
@@ -93,28 +93,28 @@ class PluginFieldWidgetCommand extends Command
             ->setName('generate:plugin:fieldwidget')
             ->setDescription($this->trans('commands.generate.plugin.fieldwidget.description'))
             ->setHelp($this->trans('commands.generate.plugin.fieldwidget.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.fieldwidget.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldwidget.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldwidget.options.plugin-id')
             )
             ->addOption(
                 'field-type',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.fieldwidget.options.field-type')
             );

--- a/src/Command/Generate/PluginImageEffectCommand.php
+++ b/src/Command/Generate/PluginImageEffectCommand.php
@@ -79,28 +79,28 @@ class PluginImageEffectCommand extends Command
             ->setName('generate:plugin:imageeffect')
             ->setDescription($this->trans('commands.generate.plugin.imageeffect.description'))
             ->setHelp($this->trans('commands.generate.plugin.imageeffect.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.imageeffect.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.imageeffect.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.imageeffect.options.plugin-id')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.imageeffect.options.description')
             );

--- a/src/Command/Generate/PluginImageFormatterCommand.php
+++ b/src/Command/Generate/PluginImageFormatterCommand.php
@@ -83,22 +83,22 @@ class PluginImageFormatterCommand extends Command
             ->setName('generate:plugin:imageformatter')
             ->setDescription($this->trans('commands.generate.plugin.imageformatter.description'))
             ->setHelp($this->trans('commands.generate.plugin.imageformatter.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.imageformatter.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.imageformatter.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.imageformatter.options.plugin-id')
             );

--- a/src/Command/Generate/PluginMailCommand.php
+++ b/src/Command/Generate/PluginMailCommand.php
@@ -92,28 +92,28 @@ class PluginMailCommand extends Command
             ->setName('generate:plugin:mail')
             ->setDescription($this->trans('commands.generate.plugin.mail.description'))
             ->setHelp($this->trans('commands.generate.plugin.mail.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.mail.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.mail.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.mail.options.plugin-id')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             );

--- a/src/Command/Generate/PluginMigrateProcessCommand.php
+++ b/src/Command/Generate/PluginMigrateProcessCommand.php
@@ -73,16 +73,16 @@ class PluginMigrateProcessCommand extends Command
             ->setName('generate:plugin:migrate:process')
             ->setDescription($this->trans('commands.generate.plugin.migrate.process.description'))
             ->setHelp($this->trans('commands.generate.plugin.migrate.process.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.process.options.class')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.process.options.plugin-id')
             );

--- a/src/Command/Generate/PluginMigrateSourceCommand.php
+++ b/src/Command/Generate/PluginMigrateSourceCommand.php
@@ -109,40 +109,40 @@ class PluginMigrateSourceCommand extends Command
             ->setName('generate:plugin:migrate:source')
             ->setDescription($this->trans('commands.generate.plugin.migrate.source.description'))
             ->setHelp($this->trans('commands.generate.plugin.migrate.source.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.source.options.class')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.source.options.plugin-id')
             )
             ->addOption(
                 'table',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.source.options.table')
             )
             ->addOption(
                 'alias',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.source.options.alias')
             )
             ->addOption(
                 'group-by',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.migrate.source.options.group-by')
             )
             ->addOption(
                 'fields',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.generate.plugin.migrate.source.options.fields')
             );

--- a/src/Command/Generate/PluginRestResourceCommand.php
+++ b/src/Command/Generate/PluginRestResourceCommand.php
@@ -83,10 +83,10 @@ class PluginRestResourceCommand extends Command
             ->setName('generate:plugin:rest:resource')
             ->setDescription($this->trans('commands.generate.plugin.rest.resource.description'))
             ->setHelp($this->trans('commands.generate.plugin.rest.resource.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rest.resource.options.class')
             )
@@ -98,25 +98,25 @@ class PluginRestResourceCommand extends Command
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rest.resource.options.plugin-id')
             )
             ->addOption(
                 'plugin-label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rest.resource.options.plugin-label')
             )
             ->addOption(
                 'plugin-url',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.generate.plugin.rest.resource.options.plugin-url')
             )
             ->addOption(
                 'plugin-states',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.generate.plugin.rest.resource.options.plugin-states')
             );

--- a/src/Command/Generate/PluginRulesActionCommand.php
+++ b/src/Command/Generate/PluginRulesActionCommand.php
@@ -83,35 +83,35 @@ class PluginRulesActionCommand extends Command
             ->setName('generate:plugin:rulesaction')
             ->setDescription($this->trans('commands.generate.plugin.rulesaction.description'))
             ->setHelp($this->trans('commands.generate.plugin.rulesaction.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rulesaction.options.class')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rulesaction.options.label')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rulesaction.options.plugin-id')
             )
-            ->addOption('type', '', InputOption::VALUE_REQUIRED, $this->trans('commands.generate.plugin.rulesaction.options.type'))
+            ->addOption('type', null, InputOption::VALUE_REQUIRED, $this->trans('commands.generate.plugin.rulesaction.options.type'))
             ->addOption(
                 'category',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.generate.plugin.rulesaction.options.category')
             )
             ->addOption(
                 'context',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.rulesaction.options.context')
             );

--- a/src/Command/Generate/PluginSkeletonCommand.php
+++ b/src/Command/Generate/PluginSkeletonCommand.php
@@ -103,25 +103,25 @@ class PluginSkeletonCommand extends Command
             ->setHelp($this->trans('commands.generate.plugin.skeleton.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'plugin-id',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.options.plugin-id')
             )
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.block.options.class')
             )
             ->addOption(
                 'services',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL| InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.common.options.services')
             );

--- a/src/Command/Generate/PluginTypeAnnotationCommand.php
+++ b/src/Command/Generate/PluginTypeAnnotationCommand.php
@@ -73,22 +73,22 @@ class PluginTypeAnnotationCommand extends Command
             ->setName('generate:plugin:type:annotation')
             ->setDescription($this->trans('commands.generate.plugin.type.annotation.description'))
             ->setHelp($this->trans('commands.generate.plugin.type.annotation.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.annotation.options.class')
             )
             ->addOption(
                 'machine-name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.annotation.options.plugin-id')
             )
             ->addOption(
                 'label',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.annotation.options.label')
             );

--- a/src/Command/Generate/PluginTypeYamlCommand.php
+++ b/src/Command/Generate/PluginTypeYamlCommand.php
@@ -74,22 +74,22 @@ class PluginTypeYamlCommand extends Command
             ->setName('generate:plugin:type:yaml')
             ->setDescription($this->trans('commands.generate.plugin.type.yaml.description'))
             ->setHelp($this->trans('commands.generate.plugin.type.yaml.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.yaml.options.class')
             )
             ->addOption(
                 'plugin-name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.yaml.options.plugin-name')
             )
             ->addOption(
                 'plugin-file-name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.type.yaml.options.plugin-file-name')
             );

--- a/src/Command/Generate/PluginViewsFieldCommand.php
+++ b/src/Command/Generate/PluginViewsFieldCommand.php
@@ -88,22 +88,22 @@ class PluginViewsFieldCommand extends Command
             ->setName('generate:plugin:views:field')
             ->setDescription($this->trans('commands.generate.plugin.views.field.description'))
             ->setHelp($this->trans('commands.generate.plugin.views.field.help'))
-            ->addOption('module', '', InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
+            ->addOption('module', null, InputOption::VALUE_REQUIRED, $this->trans('commands.common.options.module'))
             ->addOption(
                 'class',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.plugin.views.field.options.class')
             )
             ->addOption(
                 'title',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.views.field.options.title')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.plugin.views.field.options.description')
             );

--- a/src/Command/Generate/PostUpdateCommand.php
+++ b/src/Command/Generate/PostUpdateCommand.php
@@ -89,13 +89,13 @@ class PostUpdateCommand extends Command
             ->setHelp($this->trans('commands.generate.post.update.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'post-update-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.post.update.options.post-update-name')
             );

--- a/src/Command/Generate/ProfileCommand.php
+++ b/src/Command/Generate/ProfileCommand.php
@@ -85,31 +85,31 @@ class ProfileCommand extends Command
             ->setHelp($this->trans('commands.generate.profile.help'))
             ->addOption(
                 'profile',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.profile.options.profile')
             )
             ->addOption(
                 'machine-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.profile.options.machine-name')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.profile.options.description')
             )
             ->addOption(
                 'core',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.profile.options.core')
             )
             ->addOption(
                 'dependencies',
-                false,
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.profile.options.dependencies'),
                 ''
@@ -123,7 +123,7 @@ class ProfileCommand extends Command
             )
             ->addOption(
                 'distribution',
-                false,
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.profile.options.distribution')
             );

--- a/src/Command/Generate/ServiceCommand.php
+++ b/src/Command/Generate/ServiceCommand.php
@@ -104,13 +104,13 @@ class ServiceCommand extends Command
             )
             ->addOption(
                 'interface',
-                false,
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.common.service.options.interface')
             )
             ->addOption(
                 'interface_name',
-                false,
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.common.service.options.interface_name')
             )

--- a/src/Command/Generate/ThemeCommand.php
+++ b/src/Command/Generate/ThemeCommand.php
@@ -112,56 +112,56 @@ class ThemeCommand extends Command
             ->setHelp($this->trans('commands.generate.theme.help'))
             ->addOption(
                 'theme',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.theme.options.module')
             )
             ->addOption(
                 'machine-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.theme.options.machine-name')
             )
             ->addOption(
                 'theme-path',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.theme.options.module-path')
             )
             ->addOption(
                 'description',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.description')
             )
-            ->addOption('core', '', InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.theme.options.core'))
+            ->addOption('core', null, InputOption::VALUE_OPTIONAL, $this->trans('commands.generate.theme.options.core'))
             ->addOption(
                 'package',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.package')
             )
             ->addOption(
                 'global-library',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.global-library')
             )
             ->addOption(
                 'base-theme',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.base-theme')
             )
             ->addOption(
                 'regions',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.regions')
             )
             ->addOption(
                 'breakpoints',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.theme.options.breakpoints')
             );

--- a/src/Command/Generate/UpdateCommand.php
+++ b/src/Command/Generate/UpdateCommand.php
@@ -81,13 +81,13 @@ class UpdateCommand extends Command
             ->setHelp($this->trans('commands.generate.update.help'))
             ->addOption(
                 'module',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.common.options.module')
             )
             ->addOption(
                 'update-n',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.generate.update.options.update-n')
             );

--- a/src/Command/Migrate/ExecuteCommand.php
+++ b/src/Command/Migrate/ExecuteCommand.php
@@ -55,62 +55,62 @@ class ExecuteCommand extends Command
             ->addArgument('migration-ids', InputArgument::IS_ARRAY, $this->trans('commands.migrate.execute.arguments.id'))
             ->addOption(
                 'site-url',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.execute.options.site-url')
             )
             ->addOption(
                 'db-type',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.migrations.options.db-type')
             )
             ->addOption(
                 'db-host',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.execute.options.db-host')
             )
             ->addOption(
                 'db-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.execute.options.db-name')
             )
             ->addOption(
                 'db-user',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.execute.options.db-user')
             )
             ->addOption(
                 'db-pass',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-pass')
             )
             ->addOption(
                 'db-prefix',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-prefix')
             )
             ->addOption(
                 'db-port',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.execute.options.db-port')
             )
             ->addOption(
                 'exclude',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 $this->trans('commands.migrate.execute.options.exclude'),
                 []
             )
             ->addOption(
                 'source-base_path',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.source-base_path')
             );

--- a/src/Command/Migrate/RollBackCommand.php
+++ b/src/Command/Migrate/RollBackCommand.php
@@ -58,7 +58,7 @@ class RollBackCommand extends Command
             ->addArgument('migration-ids', InputArgument::IS_ARRAY, $this->trans('commands.migrate.rollback.arguments.id'))
             ->addOption(
                 'source-base_path',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.setup.options.source-base_path')
             );

--- a/src/Command/Migrate/SetupCommand.php
+++ b/src/Command/Migrate/SetupCommand.php
@@ -56,49 +56,49 @@ class SetupCommand extends Command
             ->setDescription($this->trans('commands.migrate.setup.description'))
             ->addOption(
                 'db-type',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.options.db-type')
             )
             ->addOption(
                 'db-host',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.options.db-host')
             )
             ->addOption(
                 'db-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.options.db-name')
             )
             ->addOption(
                 'db-user',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.options.db-user')
             )
             ->addOption(
                 'db-pass',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.setup.options.db-pass')
             )
             ->addOption(
                 'db-prefix',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.setup.options.db-prefix')
             )
             ->addOption(
                 'db-port',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.migrate.setup.options.db-port')
             )
             ->addOption(
                 'source-base_path',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.setup.options.source-base_path')
             );

--- a/src/Command/Module/DownloadCommand.php
+++ b/src/Command/Module/DownloadCommand.php
@@ -122,19 +122,19 @@ class DownloadCommand extends Command
             )
             ->addOption(
                 'latest',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.download.options.latest')
             )
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.install.options.composer')
             )
             ->addOption(
                 'unstable',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.install.options.unstable')
             );

--- a/src/Command/Module/InstallCommand.php
+++ b/src/Command/Module/InstallCommand.php
@@ -115,13 +115,13 @@ class InstallCommand extends Command
             )
             ->addOption(
                 'latest',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.install.options.latest')
             )
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.uninstall.options.composer')
             );

--- a/src/Command/Module/PathCommand.php
+++ b/src/Command/Module/PathCommand.php
@@ -50,7 +50,7 @@ class PathCommand extends Command
             )
             ->addOption(
                 'absolute',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.path.options.absolute')
             );

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -90,13 +90,13 @@ class UninstallCommand extends Command
             )
             ->addOption(
                 'force',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.uninstall.options.force')
             )
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.uninstall.options.composer')
             );

--- a/src/Command/Module/UpdateCommand.php
+++ b/src/Command/Module/UpdateCommand.php
@@ -59,13 +59,13 @@ class UpdateCommand extends Command
             )
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.update.options.composer')
             )
             ->addOption(
                 'simulate',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.module.update.options.simulate')
             );

--- a/src/Command/Multisite/NewCommand.php
+++ b/src/Command/Multisite/NewCommand.php
@@ -70,7 +70,7 @@ class NewCommand extends Command
             )
             ->addOption(
                 'copy-default',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.multisite.new.options.copy-default')
             );

--- a/src/Command/Rest/DebugCommand.php
+++ b/src/Command/Rest/DebugCommand.php
@@ -58,7 +58,7 @@ class DebugCommand extends Command
             )
             ->addOption(
                 'authorization',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.rest.debug.options.status')
             );

--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -84,91 +84,91 @@ class InstallCommand extends Command
             )
             ->addOption(
                 'langcode',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.langcode')
             )
             ->addOption(
                 'db-type',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.db-type')
             )
             ->addOption(
                 'db-file',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.db-file')
             )
             ->addOption(
                 'db-host',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-host')
             )
             ->addOption(
                 'db-name',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-name')
             )
             ->addOption(
                 'db-user',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-user')
             )
             ->addOption(
                 'db-pass',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-pass')
             )
             ->addOption(
                 'db-prefix',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-prefix')
             )
             ->addOption(
                 'db-port',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.migrate.execute.options.db-port')
             )
             ->addOption(
                 'site-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.site-name')
             )
             ->addOption(
                 'site-mail',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.site-mail')
             )
             ->addOption(
                 'account-name',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.account-name')
             )
             ->addOption(
                 'account-mail',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.account-mail')
             )
             ->addOption(
                 'account-pass',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.site.install.options.account-pass')
             )
             ->addOption(
                 'force',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.site.install.options.force')
             );

--- a/src/Command/Test/DebugCommand.php
+++ b/src/Command/Test/DebugCommand.php
@@ -59,7 +59,7 @@ class DebugCommand extends Command
             )
             ->addOption(
                 'test-class',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.test.debug.arguments.test-class')
             );

--- a/src/Command/Test/RunCommand.php
+++ b/src/Command/Test/RunCommand.php
@@ -91,7 +91,7 @@ class RunCommand extends Command
             )
             ->addOption(
                 'url',
-                '',
+                null,
                 InputOption::VALUE_REQUIRED,
                 $this->trans('commands.test.run.arguments.url')
             );

--- a/src/Command/Theme/DownloadCommand.php
+++ b/src/Command/Theme/DownloadCommand.php
@@ -71,7 +71,7 @@ class DownloadCommand extends Command
             ->addArgument('version', InputArgument::OPTIONAL, $this->trans('commands.theme.download.arguments.version'))
             ->addOption(
                 'composer',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.theme.download.options.composer')
             );

--- a/src/Command/Theme/InstallCommand.php
+++ b/src/Command/Theme/InstallCommand.php
@@ -64,7 +64,7 @@ class InstallCommand extends Command
             ->addArgument('theme', InputArgument::IS_ARRAY, $this->trans('commands.theme.install.options.module'))
             ->addOption(
                 'set-default',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.theme.install.options.set-default')
             );

--- a/src/Command/Theme/PathCommand.php
+++ b/src/Command/Theme/PathCommand.php
@@ -50,7 +50,7 @@ class PathCommand extends Command
             )
             ->addOption(
                 'absolute',
-                '',
+                null,
                 InputOption::VALUE_NONE,
                 $this->trans('commands.theme.path.options.absolute')
             );

--- a/src/Command/Views/DebugCommand.php
+++ b/src/Command/Views/DebugCommand.php
@@ -57,12 +57,12 @@ class DebugCommand extends Command
             )
             ->addOption(
                 'tag',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.views.debug.arguments.view-tag')
             )->addOption(
                 'status',
-                '',
+                null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.views.debug.arguments.view-status')
             );


### PR DESCRIPTION
Fix #3174.

The second argument of Symfony\Component\Console\Command\Command::addOption()
is the shortcut name of the option, and it can be set to null when not used,
as reported in the documentation:
http://api.symfony.com/3.1/Symfony/Component/Console/Command/Command.html#method_addOption

However, currently sometimes false or an empty string are used when the option
does not have a shortcut name. This could cause some confusion.

Use null everywhere as the second argument when the option does not have
a shortcut name.

The refactoring was automated with sed, and validated with php-parser with these scripts:
https://git.ao2.it/experiments/php-drupal-console-code-refactoring.git/tree

I could not use php-parser alone because it looses the original code formatting (until https://github.com/nikic/PHP-Parser/issues/344 gets fixed), but I still used it to validate what I did with sed because I didn't trust myself with sed and regexes.

Ciao ciao,
   Antonio