### PR TITLE
Print launcher version, addresses hechoendrupal/drupal-console#3164

### DIFF
--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -63,6 +63,9 @@ if (!$container) {
     exit(1);
 }
 
-$application = new Application($container);
+if (!isset($launcherVersion))
+  $launcherVersion = FALSE;
+
+$application = new Application($container, $launcherVersion);
 $application->setDefaultCommand('about');
 $application->run();

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,9 +27,52 @@ class Application extends BaseApplication
      */
     const VERSION = '1.0.0-rc18';
 
-    public function __construct(ContainerInterface $container)
+    /**
+     * @var string
+     */
+    private $launcherVersion;
+
+    public function __construct(ContainerInterface $container, $launcherVersion = FALSE)
     {
+        $this->setLauncherVersion($launcherVersion);
         parent::__construct($container, $this::NAME, $this::VERSION);
+    }
+
+    /**
+     * Returns the long version of the application.
+     *
+     * @return string The long application version
+     */
+    public function getLongVersion()
+    {
+        $output = '';
+
+        if ($this->launcherVersion) {
+          $output .= sprintf('<info>%s</info> version <comment>%s</comment>', $this->getName() . ' Launcher', $this->getLauncherVersion());
+          $output .= PHP_EOL;
+        }
+
+        if ('UNKNOWN' !== $this->getName()) {
+            if ('UNKNOWN' !== $this->getVersion()) {
+                $output .= sprintf('<info>%s</info> version <comment>%s</comment>', $this->getName(), $this->getVersion());
+            }
+            else {
+              $output .= sprintf('<info>%s</info>', $this->getName());
+            }
+        }
+        else {
+          $output .= '<info>Console Tool</info>';
+        }
+
+        return $output;
+    }
+
+    public function setLauncherVersion ($launcherVersion) {
+      $this->launcherVersion = $launcherVersion;
+    }
+
+    public function getLauncherVersion ($launcherVersion) {
+      return $this->launcherVersion;
     }
 
     /**


### PR DESCRIPTION
With this commit, drupal console will attempt to fetch and use a $launcherVersion variable. This commit needs another commit within drupal-console-launcher in which I add this variable to the global scope. 

After this, drupal console will be able to print the launcher's version, which looks like:
![image](https://cloud.githubusercontent.com/assets/503360/25722504/c92bd386-3114-11e7-9a84-6f42875e3bf9.png)

This adresses issue: hechoendrupal/drupal-console#3164