### PR TITLE
Fixes issue hechoendrupal/drupal#3305, adding missing extension_manager

### DIFF
--- a/config/services/drupal-console/config.yml
+++ b/config/services/drupal-console/config.yml
@@ -31,7 +31,7 @@ services:
       - { name: drupal.command }
   console.config_export_single:
     class: Drupal\Console\Command\Config\ExportSingleCommand
-    arguments: ['@entity_type.manager', '@config.storage']
+    arguments: ['@entity_type.manager', '@config.storage', '@console.extension_manager']
     tags:
       - { name: drupal.command }
   console.config_export_view:

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -18,6 +18,7 @@ use Drupal\Core\Config\CachedStorage;
 use Drupal\Console\Core\Style\DrupalStyle;
 use Drupal\Console\Core\Command\Shared\CommandTrait;
 use Drupal\Console\Command\Shared\ExportTrait;
+use Drupal\Console\Extension\Manager;
 
 class ExportSingleCommand extends Command
 {
@@ -46,13 +47,16 @@ class ExportSingleCommand extends Command
      *
      * @param EntityTypeManagerInterface $entityTypeManager
      * @param CachedStorage              $configStorage
+     * @param Manager                    $extensionManager
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        CachedStorage $configStorage
+        CachedStorage $configStorage,
+        Manager $extensionManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->configStorage = $configStorage;
+        $this->extensionManager = $extensionManager;
         parent::__construct();
     }
 


### PR DESCRIPTION
After a bit of digging around, it seems that `ExportSingleCommand` was missing the extension manager. This made it impossible for `config:export:single` to export to extensions and failed. Fixes hechoendrupal/drupal-console#3305