### PR TITLE
[generate:entity:content] Add 'view_builder' to config entity annotation template. Fix #3129.

### DIFF
--- a/templates/module/src/Entity/entity.php.twig
+++ b/templates/module/src/Entity/entity.php.twig
@@ -24,6 +24,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *   id = "{{ entity_name }}",
  *   label = @Translation("{{ label }}"),
  *   handlers = {
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\{{ module }}\{{ entity_class }}ListBuilder",
  *     "form" = {
  *       "add" = "Drupal\{{ module }}\Form\{{ entity_class }}Form",


### PR DESCRIPTION
This is a patch for #3129.

This allows content entities with bundles to be exposed through the core REST API without throwing errors of the form: 
```
Route entity.{{entityBundleType}}.canonical does not exist.
```

Steps to reproduce & fix manually have been well described by @tahirm in the linked issue, so I won't re-explain them here.

This patch adds a default 'view_builder' to all config entity definitions. It uses the Core `Drupal\Core\Entity\EntityViewBuilder` & doesn't bother defining a custom extension class in the same way as, for example, the 'list_builder': `Drupal\{{ module }}\{{ entity_class }}ListBuilder` as I haven't come across a use case for this level of flexibility yet. 

I checked Core to see where it extends `EntityViewBuilder` rather than using it directly and found of the >30 Drupal Core config entities, only 2 have 'view_builder' defined:
* `\Drupal\tour\Entity\Tour` => `Drupal\tour\TourViewBuilder`
* `\Drupal\block\Entity\Block` => `Drupal\block\BlockViewBuilder`

These both appear to be bundle config entities, which fits with the use case being fixed here.

I was concerned that adding 'view_builder' unconditionally to `entity.php.twig` might be too far reaching, as it doesn't look like a config entity needs it defined unless they specify a canonical route. However, it appears that the only usage of this template is for adding content entity's bundle classes in `src/Generate/EntityConfigGenerator`, so I believe this patch will only affect what it should.