### PR TITLE
Generate theme command should use right machine name question string.

### DIFF
--- a/src/Command/Generate/ThemeCommand.php
+++ b/src/Command/Generate/ThemeCommand.php
@@ -253,7 +253,7 @@ class ThemeCommand extends Command
 
         if (!$machine_name) {
             $machine_name = $io->ask(
-                $this->trans('commands.generate.module.questions.machine-name'),
+                $this->trans('commands.generate.theme.questions.machine-name'),
                 $this->stringConverter->createMachineName($theme),
                 function ($machine_name) use ($validators) {
                     return $validators->validateMachineName($machine_name);


### PR DESCRIPTION
Hi there,
While generating a theme; the machine name question is using the wrong prompt.

How to reproduce:
- Run `drupal generate:theme`
- In the machine name prompt; it says: "Enter the module machine name"; it should say "Enter the theme machine name"

This PR fixes it.