### PR TITLE
Use fully qualified namespace for @use statements

### DIFF
--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -18,8 +18,8 @@ use Symfony\Component\Routing\Route;
 /**
  * Provides routes for {{ label }} entities.
  *
- * @see Drupal\Core\Entity\Routing\AdminHtmlRouteProvider
- * @see Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider
+ * @see \Drupal\Core\Entity\Routing\AdminHtmlRouteProvider
+ * @see \Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider
  */
 class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endblock %}
 {% block class_methods %}


### PR DESCRIPTION
`@use` statements are part of documentation and are shown in rendered documentation. They should use fully qualified namespaces. This also ensures that the developer can navigate to the classes in their IDE.