### PR TITLE
[create:vocabularies] Add missing arguments to empty method call. Resolves #3271.

### DIFF
--- a/src/Utils/Create/TermData.php
+++ b/src/Utils/Create/TermData.php
@@ -66,7 +66,7 @@ class TermData extends Base
                     'vid' => $vocabulary,
                     'name' => $this->getRandom()->sentences(mt_rand(1, $nameWords), true),
                     'description' => [
-                        'value' => $this->getRandom()->sentences(),
+                        'value' => $this->getRandom()->sentences(mt_rand(1, $nameWords)),
                         'format' => 'full_html',
                     ],
                     'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,

--- a/src/Utils/Create/VocabularyData.php
+++ b/src/Utils/Create/VocabularyData.php
@@ -58,7 +58,7 @@ class VocabularyData extends Base
             $vocabulary = $this->entityTypeManager->getStorage('taxonomy_vocabulary')->create(
                 [
                     'name' => $this->getRandom()->sentences(mt_rand(1, $nameWords), true),
-                    'description' => $this->getRandom()->sentences(),
+                    'description' => $this->getRandom()->sentences(mt_rand(1, $nameWords)),
                     'vid' => Unicode::strtolower($this->getRandom()->name()),
                     'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
                     'weight' => mt_rand(0, 10),


### PR DESCRIPTION
When using drupal console to create Vocabularies or Terms, the creation of the "description" field was missing an argument in the `getRandom()->sentences()` call.  This caused the following error:

```
ArgumentCountError: Too few arguments to function Drupal\Component\Utility\Random::sentences(),
0 passed in /vendor/drupal/console/src/Utils/Create/TermData.php on line 69 and at least 1 
expected in Drupal\Component\Utility\Random->sentences() (line 192 of 
/core/lib/Drupal/Component/Utility/Random.php).
```

Solution was to supply the value provided by the user (`$nameWords`) to the function.
Test using:  
`drupal create:vocabularies --limit=5 --name-words=5` or 
`drupal create:terms --limit=5 --name-words=5` and selecting a vocab to use.