### PR TITLE
Collection routes are provided by core

### DIFF
--- a/templates/module/src/entity-content-route-provider.php.twig
+++ b/templates/module/src/entity-content-route-provider.php.twig
@@ -30,10 +30,6 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
     $collection = parent::getRoutes($entity_type);
 
     $entity_type_id = $entity_type->id();
-
-    if ($collection_route = $this->getCollectionRoute($entity_type)) {
-      $collection->add("entity.{$entity_type_id}.collection", $collection_route);
-    }
 {% if revisionable %}
 
     if ($history_route = $this->getHistoryRoute($entity_type)) {
@@ -64,31 +60,6 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
     }
 
     return $collection;
-  }
-
-  /**
-   * Gets the collection route.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   *
-   * @return \Symfony\Component\Routing\Route|null
-   *   The generated route, if available.
-   */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->hasLinkTemplate('collection') && $entity_type->hasListBuilderClass()) {
-      $entity_type_id = $entity_type->id();
-      $route = new Route($entity_type->getLinkTemplate('collection'));
-      $route
-        ->setDefaults([
-          '_entity_list' => $entity_type_id,
-          '_title' => "{$entity_type->getLabel()} list",
-        ])
-        ->setRequirement('_permission', 'access {{ label|lower }} overview')
-        ->setOption('_admin_route', TRUE);
-
-      return $route;
-    }
   }
 {% if revisionable %}
 

--- a/templates/module/src/entity-route-provider.php.twig
+++ b/templates/module/src/entity-route-provider.php.twig
@@ -29,39 +29,8 @@ class {{ entity_class }}HtmlRouteProvider extends AdminHtmlRouteProvider {% endb
   public function getRoutes(EntityTypeInterface $entity_type) {
     $collection = parent::getRoutes($entity_type);
 
-    $entity_type_id = $entity_type->id();
-
-    if ($collection_route = $this->getCollectionRoute($entity_type)) {
-      $collection->add("entity.{$entity_type_id}.collection", $collection_route);
-    }
+    // Provide your custom entity routes here.
 
     return $collection;
-  }
-
-  /**
-   * Gets the collection route.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   *
-   * @return \Symfony\Component\Routing\Route|null
-   *   The generated route, if available.
-   */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    if ($entity_type->hasLinkTemplate('collection') && $entity_type->hasListBuilderClass()) {
-      $entity_type_id = $entity_type->id();
-      $route = new Route($entity_type->getLinkTemplate('collection'));
-      $route
-        ->setDefaults([
-          '_entity_list' => $entity_type_id,
-          // Make sure this is not a TranslatableMarkup object as the
-          // TitleResolver translates this string again.
-          '_title' => (string) $entity_type->getLabel(),
-        ])
-        ->setRequirement('_permission', $entity_type->getAdminPermission())
-        ->setOption('_admin_route', TRUE);
-
-      return $route;
-    }
   }
 {% endblock %}


### PR DESCRIPTION
When generating an entity we were providing the collection route in the `HtmlRouteProvider` but this is no longer necessary since core now provides the route. This was added in Drupal 8.2.0 in [Issue #2767853 by tstoeckler: Provide a route for collections of entities](https://www.drupal.org/node/2767853).