### PR TITLE
Remove @package declarations from generated code

### DIFF
--- a/templates/module/src/Authentication/Provider/authentication-provider.php.twig
+++ b/templates/module/src/Authentication/Provider/authentication-provider.php.twig
@@ -21,8 +21,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 {% block class_declaration %}
 /**
  * Class {{ class }}.
- *
- * @package Drupal\{{module}}\Authentication\Provider
  */
 class {{ class }} implements AuthenticationProviderInterface {% endblock %}
 {% block class_variables %}

--- a/templates/module/src/Command/command.php.twig
+++ b/templates/module/src/Command/command.php.twig
@@ -25,8 +25,6 @@ use Drupal\Console\Annotations\DrupalCommand;
 /**
  * Class {{ class_name }}.
  *
- * @package Drupal\{{extension}}
- *
  * @DrupalCommand (
  *     extension="{{extension}}",
  *     extensionType="{{ extensionType }}"

--- a/templates/module/src/Controller/controller.php.twig
+++ b/templates/module/src/Controller/controller.php.twig
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
- *
- * @package Drupal\{{ module }}\Controller
  */
 class {{ class_name }} extends ControllerBase {% endblock %}
 {% block class_construct %}

--- a/templates/module/src/Controller/entity-controller.php.twig
+++ b/templates/module/src/Controller/entity-controller.php.twig
@@ -20,8 +20,6 @@ use Drupal\{{ module }}\Entity\{{ entity_class }}Interface;
  * Class {{ entity_class }}Controller.
  *
  *  Returns responses for {{ label }} routes.
- *
- * @package Drupal\{{ module }}\Controller
  */
 class {{ entity_class }}Controller extends ControllerBase implements ContainerInjectionInterface {% endblock %}
 

--- a/templates/module/src/Entity/Form/entity-settings.php.twig
+++ b/templates/module/src/Entity/Form/entity-settings.php.twig
@@ -17,8 +17,6 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Class {{ entity_class }}SettingsForm.
  *
- * @package Drupal\{{module}}\Form
- *
  * @ingroup {{module}}
  */
 class {{ entity_class }}SettingsForm extends FormBase {% endblock %}

--- a/templates/module/src/Form/entity.php.twig
+++ b/templates/module/src/Form/entity.php.twig
@@ -16,8 +16,6 @@ use Drupal\Core\Form\FormStateInterface;
 {% block class_declaration %}
 /**
  * Class {{ entity_class }}Form.
- *
- * @package Drupal\{{ module }}\Form
  */
 class {{ entity_class }}Form extends EntityForm {% endblock %}
 {% block class_methods %}

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -20,8 +20,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
- *
- * @package Drupal\{{module_name}}\Form
  */
 class {{ class_name }} extends ConfigFormBase {% endblock %}
 {% block class_construct %}

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
- *
- * @package Drupal\{{module_name}}\Form
  */
 class {{ class_name }} extends FormBase {% endblock %}
 {% block class_construct %}

--- a/templates/module/src/Routing/route-subscriber.php.twig
+++ b/templates/module/src/Routing/route-subscriber.php.twig
@@ -17,7 +17,6 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * Class {{ class }}.
  *
- * @package Drupal\{{module}}\Routing
  * Listens to the dynamic route events.
  */
 class {{ class }} extends RouteSubscriberBase {% endblock %}

--- a/templates/module/src/TwigExtension/twig-extension.php.twig
+++ b/templates/module/src/TwigExtension/twig-extension.php.twig
@@ -14,8 +14,6 @@ namespace Drupal\{{module}}\TwigExtension;
 {% block class_declaration %}
 /**
  * Class {{ class }}.
- *
- * @package Drupal\{{module}}
  */
 class {{ class }} extends \Twig_Extension {% endblock %}
 

--- a/templates/module/src/cache-context.php.twig
+++ b/templates/module/src/cache-context.php.twig
@@ -16,8 +16,6 @@ use Drupal\Core\Cache\Context\CacheContextInterface;
 {% block class_declaration %}
 /**
 * Class {{ class }}.
-*
-* @package Drupal\{{module}}
 */
 class {{ class }} implements CacheContextInterface {% endblock %}
 

--- a/templates/module/src/event-subscriber.php.twig
+++ b/templates/module/src/event-subscriber.php.twig
@@ -16,8 +16,6 @@ use Symfony\Component\EventDispatcher\Event;
 {% block class_declaration %}
 /**
  * Class {{ class }}.
- *
- * @package Drupal\{{module}}
  */
 class {{ class }} implements EventSubscriberInterface {% endblock %}
 

--- a/templates/module/src/service-interface.php.twig
+++ b/templates/module/src/service-interface.php.twig
@@ -11,7 +11,5 @@ namespace Drupal\{{module}};
 {% block interface_declaration %}
 /**
  * Interface {{ interface }}.
- *
- * @package Drupal\{{module}}
  */
 interface {{ interface }} {% endblock %}

--- a/templates/module/src/service.php.twig
+++ b/templates/module/src/service.php.twig
@@ -10,8 +10,6 @@ namespace Drupal\{{module}};{% endblock %}
 {% block class_declaration %}
 /**
  * Class {{ class }}.
- *
- * @package Drupal\{{module}}
  */
 class {{ class }}{% if(interface is defined and interface) %} implements {{ interface }}{% endif %} {% endblock %}
 {% block class_construct %}


### PR DESCRIPTION
Many of the classes are generated with an `@package` declaration. This is a standard from PhpDoc and is adopted by other popular CMS's like Wordpress but not by Drupal. It is not defined in the Drupal coding standards, and is not used by Drupal core and contrib modules. This information duplicates the namespace declaration, and is completely useless.

This probably found its way into Drupal Console because it is added to class docblocks automatically by PHPStorm.