### PR TITLE
Quoting route names is not necessary

### DIFF
--- a/templates/module/links.action-entity-content.yml.twig
+++ b/templates/module/links.action-entity-content.yml.twig
@@ -3,7 +3,7 @@ entity.{{ entity_name }}.add_form:
 {% if not bundle_entity_type %}
   route_name: entity.{{ entity_name }}.add_form
 {% else %}
-  route_name: 'entity.{{ entity_name }}.add_page'
+  route_name: entity.{{ entity_name }}.add_page
 {% endif %}
   title: 'Add {{ label }}'
   appears_on:

--- a/templates/module/links.action-entity.yml.twig
+++ b/templates/module/links.action-entity.yml.twig
@@ -1,5 +1,5 @@
 entity.{{ entity_name }}.add_form:
-  route_name: 'entity.{{ entity_name }}.add_form'
+  route_name: entity.{{ entity_name }}.add_form
   title: 'Add {{ label }}'
   appears_on:
     - entity.{{ entity_name }}.collection


### PR DESCRIPTION
This is a really minor fix. When specifying routes in YAML files it is not necessary to quote them, since they are resolved to route names, and not raw strings. In almost all of our generated code this is handled correctly, save for two instances when generating action links.