### PR TITLE
Fix show themes on theme:install command

### DIFF
--- a/src/Command/Theme/InstallCommand.php
+++ b/src/Command/Theme/InstallCommand.php
@@ -101,7 +101,9 @@ class InstallCommand extends Command
             while (true) {
                 $theme_name = $io->choiceNoList(
                     $this->trans('commands.theme.install.questions.theme'),
-                    array_keys($theme_list)
+                    array_keys($theme_list),
+                    null,
+                    true
                 );
 
                 if (empty($theme_name)) {

--- a/src/Command/Theme/UninstallCommand.php
+++ b/src/Command/Theme/UninstallCommand.php
@@ -93,7 +93,9 @@ class UninstallCommand extends Command
             while (true) {
                 $theme_name = $io->choiceNoList(
                     $this->trans('commands.theme.uninstall.questions.theme'),
-                    array_keys($theme_list)
+                    array_keys($theme_list),
+                    null,
+                    true
                 );
 
                 if (empty($theme_name)) {


### PR DESCRIPTION
Improved UX to end the process to include themes to be installed , accepting an empty value as end of the process.
![console](https://user-images.githubusercontent.com/8105777/27455716-8168da36-575b-11e7-92fd-720024216966.png)
