### PR TITLE
[generate:entity:content] Improve command options

### DIFF
--- a/src/Command/Generate/EntityCommand.php
+++ b/src/Command/Generate/EntityCommand.php
@@ -150,12 +150,12 @@ abstract class EntityCommand extends Command
         // --base-path option
         $base_path = $input->getOption('base-path');
         if (!$base_path) {
-            $base_path = $this->getDefaultBasePath();
+            $base_path = $io->ask(
+                $this->trans('commands.'.$commandKey.'.questions.base-path'),
+                $this->getDefaultBasePath()
+            );
         }
-        $base_path = $io->ask(
-            $this->trans('commands.'.$commandKey.'.questions.base-path'),
-            $base_path
-        );
+
         if (substr($base_path, 0, 1) !== '/') {
             // Base path must start with a leading '/'.
             $base_path = '/' . $base_path;

--- a/src/Command/Generate/EntityContentCommand.php
+++ b/src/Command/Generate/EntityContentCommand.php
@@ -81,21 +81,21 @@ class EntityContentCommand extends EntityCommand
         $this->addOption(
             'has-bundles',
             null,
-            InputOption::VALUE_NONE,
+            InputOption::VALUE_OPTIONAL,
             $this->trans('commands.generate.entity.content.options.has-bundles')
         );
 
         $this->addOption(
             'is-translatable',
             null,
-            InputOption::VALUE_NONE,
+            InputOption::VALUE_OPTIONAL,
             $this->trans('commands.generate.entity.content.options.is-translatable')
         );
 
         $this->addOption(
             'revisionable',
             null,
-            InputOption::VALUE_NONE,
+            InputOption::VALUE_OPTIONAL,
             $this->trans('commands.generate.entity.content.options.revisionable')
         );
     }
@@ -108,29 +108,45 @@ class EntityContentCommand extends EntityCommand
         parent::interact($input, $output);
         $io = new DrupalStyle($input, $output);
 
-        // --bundle-of option
-        $bundle_of = $input->getOption('has-bundles');
-        if (!$bundle_of) {
-            $bundle_of = $io->confirm(
-                $this->trans('commands.generate.entity.content.questions.has-bundles'),
-                false
-            );
-            $input->setOption('has-bundles', $bundle_of);
-        }
+        // --has-bundles option.
+        $this->interactBooleanQuestion($input, $io, 'has-bundles', false);
 
         // --is-translatable option
-        $is_translatable = $io->confirm(
-            $this->trans('commands.generate.entity.content.questions.is-translatable'),
-            true
-        );
-        $input->setOption('is-translatable', $is_translatable);
+        $this->interactBooleanQuestion($input, $io, 'is-translatable', true);
 
         // --revisionable option
-        $revisionable = $io->confirm(
-            $this->trans('commands.generate.entity.content.questions.revisionable'),
-            true
+        $this->interactBooleanQuestion($input, $io, 'revisionable', true);
+    }
+
+    /**
+     * Helper to ask for boolean option.
+     *
+     * @param InputInterface  $input
+     * @param DrupalStyle     $io
+     * @param string          $option
+     * @param bool            $default
+     */
+    protected function interactBooleanQuestion(InputInterface $input, DrupalStyle $io, $option, $default = true) {
+      // If no option flag has been set, we ask for manual input.
+      if (!$input->hasOption($option)) {
+        $set_value = $io->confirm(
+          $this->trans('commands.generate.entity.content.questions.' . $option),
+          (bool) $default
         );
-        $input->setOption('revisionable', $revisionable);
+      }
+      else {
+        $value = $input->getOption($option);
+        // When the value of the option is "0" or "false" the option is disabled.
+        if (isset($value) && $value === "0" || strtolower($value) === "false") {
+          $set_value = FALSE;
+        }
+        // ... otherwise the option is enabled.
+        else {
+          $set_value = TRUE;
+        }
+      }
+
+      $input->setOption($option, $set_value);
     }
 
     /**


### PR DESCRIPTION
In the current `drupal generate:entity:content` command there are some problems, so you could not generate an entity without any manual confirmation step. The base-path set via `--base-path="..."` currently only is set as default for the question displayed after running the command. With the options `has-bundles`, `is-translatable` and `revisionable` there is the problem of not beeing able to disable those settings via the command line.

With the given PR I try to fix those problems, so a command like below, will run without the need of any manual confirmations:
```
drupal generate:entity:content --module=kswertung --entity-class=ResultEntity --entity-name=ksresult --label="Result" --base-path="/kswertung" --revisionable --has-bundles=0 --is-translatable=false
```

The PR adds the possibility to disable an option by setting it to _0_ or _false_.