### PR TITLE
Allow inherited ModuleInstaller classes to InstallDependencyCommand.

### DIFF
--- a/src/Command/Module/InstallDependencyCommand.php
+++ b/src/Command/Module/InstallDependencyCommand.php
@@ -18,7 +18,7 @@ use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Core\Style\DrupalStyle;
 use Drupal\Console\Utils\Site;
 use Drupal\Console\Utils\Validator;
-use Drupal\Core\ProxyClass\Extension\ModuleInstaller;
+use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Console\Core\Utils\ChainQueue;
 
 /**
@@ -38,13 +38,13 @@ class InstallDependencyCommand extends Command
     protected $site;
 
     /**
- * @var Validator
-*/
+     * @var Validator
+     */
     protected $validator;
 
     /**
- * @var ModuleInstaller
-*/
+     * @var ModuleInstallerInterface
+     */
     protected $moduleInstaller;
 
     /**
@@ -57,12 +57,13 @@ class InstallDependencyCommand extends Command
      *
      * @param Site       $site
      * @param Validator  $validator
+     * @param ModuleInstallerInterface $moduleInstaller
      * @param ChainQueue $chainQueue
      */
     public function __construct(
         Site $site,
         Validator $validator,
-        ModuleInstaller $moduleInstaller,
+        ModuleInstallerInterface $moduleInstaller,
         ChainQueue $chainQueue
     ) {
         $this->site = $site;


### PR DESCRIPTION
I'm getting a Drupal Console error in my project b/c I'm extending the Drupal "ModuleInstaller" class. My code is then passing in my overridden class via services to Drupal Console. I'm not 100% sure this is right, but this feels like it should be accepting the ModuleInstallerInterface instead of just ModuleInstaller. I'm not that familiar with "ProxyClass"es which is what I'm removing, so I'm not confident this is definitely correct. Please advise if you don't think this is an appropriate bugfix.

### Other:
* Fixed comment styles.
* Added `@param` to constructor comment.