### PR TITLE
Add cache:tag:invalidate command.

### DIFF
--- a/config/services/cache.yml
+++ b/config/services/cache.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@console.drupal_api', '@console.site', '@class_loader', '@request_stack']
     tags:
       - { name: drupal.command }
+  console.cache_tag_invalidate:
+    class: Drupal\Console\Command\Cache\TagInvalidateCommand
+    arguments: ['@cache_tags.invalidator']
+    tags:
+      - { name: drupal.command }

--- a/src/Command/Cache/TagInvalidateCommand.php
+++ b/src/Command/Cache/TagInvalidateCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Cache\TagInvalidateCommand.
+ */
+
+namespace Drupal\Console\Command\Cache;
+
+use Drupal\Console\Core\Command\Shared\CommandTrait;
+use Drupal\Console\Core\Style\DrupalStyle;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TagInvalidateCommand extends Command
+{
+    use CommandTrait;
+
+    /**
+     * @var CacheTagsInvalidatorInterface
+     */
+    protected $invalidator;
+
+    /**
+     * TagInvalidateCommand constructor.
+     *
+     * @param CacheTagsInvalidatorInterface $invalidator
+     */
+    public function __construct(CacheTagsInvalidatorInterface $invalidator)
+    {
+        parent::__construct();
+        $this->invalidator = $invalidator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('cache:tag:invalidate')
+            ->setDescription($this->trans('commands.cache.tag.invalidate.description'))
+            ->addArgument(
+                'tag',
+                InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+                $this->trans('commands.cache.tag.invalidate.options.tag')
+            )
+            ->setAliases(['cti']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+        $tags = $input->getArgument('tag');
+
+        $io->comment(
+            sprintf(
+                $this->trans('commands.cache.tag.invalidate.messages.start'),
+                implode(', ', $tags)
+            )
+        );
+
+        $this->invalidator->invalidateTags($tags);
+        $io->success($this->trans('commands.cache.tag.invalidate.messages.completed'));
+    }
+}


### PR DESCRIPTION
This is a command for accessing Drupal's cache tag invalidator, which allows clearing caches more specifically than complete deletion, if you know what tags a cache entry is dependent on.

For example, when you're debugging a view, you can invalidate all related cache entries with `drupal cache:tag:invalidate config:views.view.frontpage` without having to actually trigger the view's save operation.