### PR TITLE
Update Symfony component requirements to allow 3.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,8 @@
         "psy/psysh": "0.6.* || ~0.8",
         "symfony/css-selector": "~2.8|~3.0",
         "symfony/dom-crawler": "~2.8|~3.0",
-        "symfony/expression-language": "~2.8",
-        "symfony/http-foundation": "~2.8"
+        "symfony/expression-language": "~2.8|~3.0",
+        "symfony/http-foundation": "~2.8|~3.0"
     },
     "bin": ["bin/drupal"],
     "config": {


### PR DESCRIPTION
Drupal 8.4 updates Symfony component requirements to ~3.2, so will conflict with the current ~2.8 requirement.

The following PRs will also be needed:
 - hechoendrupal/drupal-console-core#209
 - hechoendrupal/drupal-console-extend-plugin#16

Drupal 8.3 projects will continue to install Symfony 2.8 components where they are requirements of both drupal/core and drupal/console due to Drupal 8.3's constraint of ~2.8, but components that are only requirements of drupal/console may be updated to 3.x versions. This shouldn't be a problem as long as drupal/console doesn't use any deprecated features in those 2.8 components.

Fixes #3353, Fixes #3317, Fixes #3293
