### PR TITLE
Add autoload path for when console is symlinked in vendor

### DIFF
--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -20,8 +20,12 @@ if (file_exists(__DIR__ . '/../autoload.local.php')) {
     include_once __DIR__ . '/../autoload.local.php';
 } else {
     $autoloaders = [
+        // When a dependency of another project (vendor/drupal/console/bin/drupal.php)
         __DIR__ . '/../../../autoload.php',
-        __DIR__ . '/../vendor/autoload.php'
+        // When console is the root project (bin/drupal.php)
+        __DIR__ . '/../vendor/autoload.php',
+        // When symlinked in vendors/, __DIR__ is not within the root project.
+        dirname($_SERVER['PWD'] . '/' . $_SERVER['SCRIPT_NAME']) . '/../autoload.php',
     ];
 }
 


### PR DESCRIPTION
When trying to test making corresponding changes to multiple components of Drupal Console, I used [drupal-project](https://github.com/drupal-composer/drupal-project), and added some repository overrides in composer.json to use the local packages:

```
{
    "repositories": [
        {
            "type": "path",
            "url": "/Users/geoff/git/drupal-console"
        },
        {
            "type": "path",
            "url": "/Users/geoff/git/drupal-console-core"
        },
        {
            "type": "path",
            "url": "/Users/geoff/git/drupal-console-extend-plugin"
        }
}
```

However, this means that when searching for the autoloader, `__DIR__` corresponds to the target of the symlinks rather than to the path within the drupal-project's vendor directory and execution fails.

This PR adds another path to check for the autoloader based on the current working directory and the path to the `drupal` script, which is unnaffected by the symlinks.