### PR TITLE
[config:export] Create paths when exporting collections.

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -143,7 +143,7 @@ class ExportCommand extends Command
                 $collection_storage = $this->storage->createCollection($collection);
                 $collection_path = str_replace('.', '/', $collection);
                 if (!$tar) {
-                  mkdir("$directory/$collection_path", 0755, TRUE);
+                    mkdir("$directory/$collection_path", 0755, true);
                 }
                 foreach ($collection_storage->listAll() as $name) {
                     $configName = "$collection_path/$name.yml";

--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -141,8 +141,12 @@ class ExportCommand extends Command
             // Get all override data from the remaining collections.
             foreach ($this->storage->getAllCollectionNames() as $collection) {
                 $collection_storage = $this->storage->createCollection($collection);
+                $collection_path = str_replace('.', '/', $collection);
+                if (!$tar) {
+                  mkdir("$directory/$collection_path", 0755, TRUE);
+                }
                 foreach ($collection_storage->listAll() as $name) {
-                    $configName = str_replace('.', '/', $collection) . "/$name.yml";
+                    $configName = "$collection_path/$name.yml";
                     $configData = $collection_storage->read($name);
                     if ($removeUuid) {
                         unset($configData['uuid']);


### PR DESCRIPTION
When I added the code for exporting config translations in #3182 / #3185, I forgot some `mkdir` calls. ;) So translations are only exported if the language folders already exist, but not when you're exporting for the first time or after creating a new language. (Tar mode is unaffected)