### PR TITLE
Don't wipe cache during cron run

### DIFF
--- a/config/services/cron.yml
+++ b/config/services/cron.yml
@@ -1,7 +1,7 @@
 services:
   console.cron_execute:
     class: Drupal\Console\Command\Cron\ExecuteCommand
-    arguments: ['@module_handler', '@lock', '@state', '@console.chain_queue']
+    arguments: ['@module_handler', '@lock', '@state']
     tags:
       - { name: drupal.command }
   console.cron_release:

--- a/src/Command/Cron/ExecuteCommand.php
+++ b/src/Command/Cron/ExecuteCommand.php
@@ -15,7 +15,6 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Console\Core\Style\DrupalStyle;
-use Drupal\Console\Core\Utils\ChainQueue;
 
 class ExecuteCommand extends Command
 {
@@ -35,28 +34,20 @@ class ExecuteCommand extends Command
     protected $state;
 
     /**
-     * @var ChainQueue
-     */
-    protected $chainQueue;
-
-    /**
      * DebugCommand constructor.
      *
      * @param ModuleHandlerInterface $moduleHandler
      * @param LockBackendInterface   $lock
      * @param StateInterface         $state
-     * @param ChainQueue             $chainQueue
      */
     public function __construct(
         ModuleHandlerInterface $moduleHandler,
         LockBackendInterface $lock,
-        StateInterface $state,
-        ChainQueue $chainQueue
+        StateInterface $state
     ) {
         $this->moduleHandler = $moduleHandler;
         $this->lock = $lock;
         $this->state = $state;
-        $this->chainQueue = $chainQueue;
         parent::__construct();
     }
 
@@ -120,8 +111,6 @@ class ExecuteCommand extends Command
 
         $this->state->set('system.cron_last', REQUEST_TIME);
         $this->lock->release('cron');
-
-        $this->chainQueue->addCommand('cache:rebuild', ['cache' => 'all']);
 
         $io->success($this->trans('commands.cron.execute.messages.success'));
 


### PR DESCRIPTION
Fix #3480

Wiping cache manually can kill site performance so forcing it during an
operation that will run very often on most sites could be very damaging.

If a user _needs_ to clear caches at set intervals they can still do so using
the explicit cache commands.