### PR TITLE
Fix #3503: prints exception variable contents

### DIFF
--- a/src/Command/Update/EntitiesCommand.php
+++ b/src/Command/Update/EntitiesCommand.php
@@ -87,8 +87,8 @@ class EntitiesCommand extends Command
         } catch (EntityStorageException $e) {
             /* @var Error $variables */
             $variables = Error::decodeException($e);
-            $io->info($this->trans('commands.update.entities.messages.error'));
-            $io->info($variables);
+            $io->errorLite($this->trans('commands.update.entities.messages.error'));
+            $io->error(strtr('%type: @message in %function (line %line of %file).', $variables));
         }
 
         $this->state->set('system.maintenance_mode', false);


### PR DESCRIPTION
There are other approaches here, but this is the most straightforward. Initially I was using `Error::renderExceptionSafe` which will render the exception into a string, but it contains html markup which doesn't play nice with console. The markup can then be passed to `Drupal\Component\Render\PlainTextOutput::renderFromHtml` which will strip the tags. But ultimately it's just a round about way to accomplish what I have here. 

`_drupal_log_exception` uses `strtr` so I took inspiration from there. If there is a more "drupal" way to render the exception contents into a plaintext string then that might be better.