### PR TITLE
Skip the reset password page and just login.

### DIFF
--- a/src/Command/User/LoginUrlCommand.php
+++ b/src/Command/User/LoginUrlCommand.php
@@ -75,7 +75,7 @@ class LoginUrlCommand extends Command
             return 1;
         }
 
-        $url = user_pass_reset_url($user);
+        $url = user_pass_reset_url($user) . '/login';
         $io->success(
             sprintf(
                 $this->trans('commands.user.login.url.messages.url'),


### PR DESCRIPTION
When creating a one time user login link a reset password page is shown with a "login" button to actually login. This change skips that page and just logins directly into the user account.