### PR TITLE
Adds aegir support.

### DIFF
--- a/src/Bootstrap/ConsoleSettings.php
+++ b/src/Bootstrap/ConsoleSettings.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\Console\Bootstrap;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Database\Database;
+
+/**
+ * Read only settings that are initialized with the class.
+ *
+ * @ingroup utility
+ */
+final class ConsoleSettings {
+
+  /**
+   * Array with the settings.
+   *
+   * @var array
+   */
+  private $storage = [];
+
+  /**
+   * Singleton instance.
+   *
+   * @var \Drupal\Console\Bootstrap/ConsoleSettings
+   */
+  private static $instance = NULL;
+
+  /**
+   * Constructor.
+   *
+   * @param array $settings
+   *   Array with the settings.
+   */
+  public function __construct(array $settings) {
+    $this->storage = $settings;
+    self::$instance = $this;
+  }
+
+  /**
+   * Returns the settings instance.
+   *
+   * A singleton is used because this class is used before the container is
+   * available.
+   *
+   * @return \Drupal\Console\Bootstrap\ConsoleSettings
+   *
+   * @throws \BadMethodCallException
+   *   Thrown when the settings instance has not been initialized yet.
+   */
+  public static function getInstance() {
+    if (self::$instance === NULL) {
+      throw new \BadMethodCallException('ConsoleSettings::$instance is not initialized yet. Whatever you are trying to do, it might be too early for that. You could call ConsoleSettings::initialize(), but it is probably better to wait until it is called in the regular way. Also check for recursions.');
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Protects creating with clone.
+   */
+  private function __clone() {
+  }
+
+  /**
+   * Prevents settings from being serialized.
+   */
+  public function __sleep() {
+    throw new \LogicException('ConsoleSettings can not be serialized. This probably means you are serializing an object that has an indirect reference to the ConsoleSettings object. Adjust your code so that is not necessary.');
+  }
+
+  /**
+   * Returns a setting.
+   *
+   * ConsoleSettings can be set in settings.php in the $settings array and requested
+   * by this function. ConsoleSettings should be used over configuration for read-only,
+   * possibly low bootstrap configuration that is environment specific.
+   *
+   * @param string $name
+   *   The name of the setting to return.
+   * @param mixed $default
+   *   (optional) The default value to use if this setting is not set.
+   *
+   * @return mixed
+   *   The value of the setting, the provided default if not set.
+   */
+  public static function get($name, $default = NULL) {
+    return isset(self::$instance->storage[$name]) ? self::$instance->storage[$name] : $default;
+  }
+
+  /**
+   * Bootstraps settings.php and the ConsoleSettings singleton.
+   *
+   * @param string $app_root
+   *   The app root.
+   * @param string $site_path
+   *   The current site path.
+   * @param \Composer\Autoload\ClassLoader $class_loader
+   *   The class loader that is used for this request. Passed by reference and
+   *   exposed to the local scope of settings.php, so as to allow it to be
+   *   decorated with Symfony's ApcClassLoader, for example.
+   *
+   * @see default.settings.php
+   */
+  public static function initialize($app_root, $site_path, &$class_loader) {
+    // Export these settings.php variables to the global namespace.
+    global $config_directories, $config;
+    $settings = [];
+    $config = [];
+    $databases = [];
+
+    if (is_readable($app_root . '/' . $site_path . '/settings.php')) {
+      require $app_root . '/' . $site_path . '/settings.php';
+    }
+
+    // If datases is not set, check if drushrc.php contains valid setting (Aegir).
+    $items = array(
+      'driver' => 'db_type',
+      'database' => 'db_name',
+      'username'=> 'db_user',
+      'password' => 'db_passwd',
+      'host' => 'db_host',
+      'port' => 'db_port',
+    );
+
+    $db_settings_fail = TRUE;
+    foreach ($items as $key => $item) {
+      if (!empty($databases['default']['default'][$key])) {
+        $db_settings_fail = FALSE;
+        break;
+      }
+    }
+
+    if ($db_settings_fail) {
+      if (is_readable($app_root . '/' . $site_path . '/settings.php')) {
+        require $app_root . '/' . $site_path . '/drushrc.php';
+        foreach ($items as $key => $item) {
+          if (!empty($options[$item])) {
+            $databases['default']['default'][$key] = $options[$item];
+          }
+        }
+      }
+    }
+
+    // Initialize Database.
+    Database::setMultipleConnectionInfo($databases);
+
+    // Initialize ConsoleSettings.
+    new ConsoleSettings($settings);
+  }
+
+  /**
+   * Generates a prefix for APCu user cache keys.
+   *
+   * A standardized prefix is useful to allow visual inspection of an APCu user
+   * cache. By default, this method will produce a unique prefix per site using
+   * the hash salt. If the setting 'apcu_ensure_unique_prefix' is set to FALSE
+   * then if the caller does not provide a $site_path only the Drupal root will
+   * be used. This allows WebTestBase to use the same prefix ensuring that the
+   * number of APCu items created during a full test run is kept to a minimum.
+   * Additionally, if a multi site implementation does not use site specific
+   * module directories setting apcu_ensure_unique_prefix would allow the sites
+   * to share APCu cache items.
+   *
+   * @param $identifier
+   *   An identifier for the prefix. For example, 'class_loader' or
+   *   'cache_backend'.
+   *
+   * @return string
+   *   The prefix for APCu user cache keys.
+   */
+  public static function getApcuPrefix($identifier, $root, $site_path = '') {
+    if (static::get('apcu_ensure_unique_prefix', TRUE)) {
+      return 'drupal.' . $identifier . '.' . \Drupal::VERSION . '.' . static::get('deployment_identifier') . '.' . hash_hmac('sha256', $identifier, static::get('hash_salt') . '.' . $root . '/' . $site_path);
+    }
+    return 'drupal.' . $identifier . '.' . \Drupal::VERSION . '.' . static::get('deployment_identifier') . '.' . Crypt::hashBase64($root . '/' . $site_path);
+  }
+
+}

--- a/src/Bootstrap/DrupalKernel.php
+++ b/src/Bootstrap/DrupalKernel.php
@@ -5,6 +5,7 @@ namespace Drupal\Console\Bootstrap;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\Core\DrupalKernel as DrupalKernelBase;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+use Drupal\Console\Bootstrap\ConsoleSettings;
 
 /**
  * Class DrupalKernel
@@ -25,9 +26,62 @@ class DrupalKernel extends DrupalKernelBase
     {
         $kernel = new static($environment, $class_loader, $allow_dumping, $app_root);
         static::bootEnvironment($app_root);
-        $kernel->initializeSettings($request);
+        $kernel->consoleInitializeSettings($request);
         $kernel->handle($request);
         return $kernel;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function consoleInitializeSettings(Request $request) {
+      $site_path = static::findSitePath($request);
+      $this->setSitePath($site_path);
+      $class_loader_class = get_class($this->classLoader);
+      ConsoleSettings::initialize($this->root, $site_path, $this->classLoader);
+
+      // Initialize our list of trusted HTTP Host headers to protect against
+      // header attacks.
+      $host_patterns = ConsoleSettings::get('trusted_host_patterns', []);
+      if (PHP_SAPI !== 'cli' && !empty($host_patterns)) {
+        if (static::setupTrustedHosts($request, $host_patterns) === FALSE) {
+          throw new BadRequestHttpException('The provided host name is not valid for this server.');
+        }
+      }
+
+      // If the class loader is still the same, possibly
+      // upgrade to an optimized class loader.
+      if ($class_loader_class == get_class($this->classLoader)
+          && ConsoleSettings::get('class_loader_auto_detect', TRUE)) {
+        $prefix = ConsoleSettings::getApcuPrefix('class_loader', $this->root);
+        $loader = NULL;
+
+        // We autodetect one of the following three optimized classloaders, if
+        // their underlying extension exists.
+        if (function_exists('apcu_fetch')) {
+          $loader = new ApcClassLoader($prefix, $this->classLoader);
+        }
+        elseif (extension_loaded('wincache')) {
+          $loader = new WinCacheClassLoader($prefix, $this->classLoader);
+        }
+        elseif (extension_loaded('xcache')) {
+          $loader = new XcacheClassLoader($prefix, $this->classLoader);
+        }
+        if (!empty($loader)) {
+          $this->classLoader->unregister();
+          // The optimized classloader might be persistent and store cache misses.
+          // For example, once a cache miss is stored in APCu clearing it on a
+          // specific web-head will not clear any other web-heads. Therefore
+          // fallback to the composer class loader that only statically caches
+          // misses.
+          $old_loader = $this->classLoader;
+          $this->classLoader = $loader;
+          // Our class loaders are preprended to ensure they come first like the
+          // class loader they are replacing.
+          $old_loader->register(TRUE);
+          $loader->register(TRUE);
+        }
+      }
     }
 
     /**


### PR DESCRIPTION
Hi, this code works for me, and I expect it might work for others too. That said, I'm a beginner in object oriented programming and Drupal 8, so there probably is a nicer way to get this issue fixed. The database settings are created in Drupal\Core\Site\Settings, and this is a final class. As I understand it this makes it impossible to extend. I ended up copying code from Drupal core to drupal console, which is not nice.

The database settings are read from drushrc.php which is located in the site directory (same location as settings.php).

This is how the database settings exist in my drusrc.php:

$options['db_type'] = 'mysql';
$options['db_host'] = 'localhost';
$options['db_port'] = '3306';
$options['db_passwd'] = 'averystrongpass';
$options['db_name'] = 'thedbname';
$options['db_user'] = 'thedbusername';

I expect aegir always makes the settings available in this way in drushrc.php, but I'm not sure. I haven't looked into the aegir project to check how drushrc.php is created. So there is a possibility that in other environments the settings are stored differently. Nor do I know if there are situations where aegir sites have more then 1 database connection, and how this works if so.