### PR TITLE
[update:execute] Warn and return 0 if there are no pending updates

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -136,7 +136,7 @@ class ExecuteCommand extends Command
 
         if (!$this->checkUpdates($start, $updates)) {
             if ($this->module === 'all') {
-                $io->error(
+                $io->warning(
                     sprintf(
                         $this->trans(
                             'commands.update.execute.messages.no-pending-updates'
@@ -144,7 +144,7 @@ class ExecuteCommand extends Command
                     )
                 );
             } else {
-                $io->error(
+                $io->warning(
                     sprintf(
                         $this->trans(
                             'commands.update.execute.messages.no-module-updates'
@@ -154,7 +154,7 @@ class ExecuteCommand extends Command
                 );
             }
 
-            return 1;
+            return 0;
         }
 
         $maintenanceMode = $this->state->get('system.maintenance_mode', false);


### PR DESCRIPTION
### Problem/Motivation
A recent change to the update:execute command has made me a sad panda. As of 1.0.2, if there are no pending updates, an error is output and 1 is returned. This broke our Travis CI builds over at acquia/lightning: https://travis-ci.org/acquia/lightning/jobs/272902792

### Solution
I discussed this problem briefly with @jmolivas on Slack and he said it should warn, not error, and return 0.