### PR TITLE
[generate:entity:content] Omit 'access /entity type/ overview' permission since it does nothing.

### DIFF
--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -12,9 +12,6 @@ delete {{ label|lower }} entities:
 edit {{ label|lower }} entities:
   title: 'Edit {{ label }} entities'
 
-access {{ label|lower }} overview:
-  title: 'Access the {{ label }} overview page'
-
 view published {{ label|lower }} entities:
   title: 'View published {{ label }} entities'
 


### PR DESCRIPTION
If I understand things correctly, access to content entity listings/collection used to be provided by the generated entity, but was recently [passed off to core](https://github.com/hechoendrupal/drupal-console/pull/3344). This means that unless the route provider is modified after generation, it's the *administer foo entities* permission that opens the door, not *access foo overview*.

If I've gotten this right - I'm a relative newb to entity building in D8 - it's probably confusing to keep the latter permission lying around.
