### PR TITLE
Properly record ran post_update functions.

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -301,6 +301,7 @@ class ExecuteCommand extends Command
                     $function,
                     $context
                 );
+                $this->postUpdateRegistry->registerInvokedUpdates([$function]);
             }
         }
 


### PR DESCRIPTION
If this isn't done, Drupal UI will continue to report that db updates are pending. 
Note, I considered placing this outside of the foreach calls and recording all post updates at once; however that would cause problems if one failed but not the others.