### PR TITLE
Avoid run of Request handle() and use of container at compiler pass to fix issues 3091 and 3553

### DIFF
--- a/src/Bootstrap/Drupal.php
+++ b/src/Bootstrap/Drupal.php
@@ -152,11 +152,19 @@ class Drupal
             // needs to be set manually to allow use of the cache files.
             FileCacheFactory::setPrefix($this->drupalFinder->getDrupalRoot());
 
+            // Invalidate container to ensure rebuild of any cached state
+            // when boot is processed.
             $drupalKernel->invalidateContainer();
+
             // Looks that the boot process is handling an initializeContainer
             // so looks that rebuildContainer repeats what we finally do in boot().
             //$drupalKernel->rebuildContainer();
+
+            // Load legacy libraries, modules, register stream wrapper, and push
+            // request to request stack but without trigger processing of '/'
+            // request that invokes hooks like hook_page_attachments().
             $drupalKernel->boot();
+            $drupalKernel->preHandle($request);
 
             if ($debug) {
                 $io->writeln("\r\033[K\033[1A\r<info>✔</info>");

--- a/src/Bootstrap/Drupal.php
+++ b/src/Bootstrap/Drupal.php
@@ -10,6 +10,8 @@ use Drupal\Console\Core\Style\DrupalStyle;
 use Drupal\Console\Core\Utils\ArgvInputReader;
 use Drupal\Console\Core\Bootstrap\DrupalConsoleCore;
 use Drupal\Console\Core\Utils\DrupalFinder;
+use Drupal\Component\FileCache\FileCacheFactory;
+use Drupal\Core\Site\Settings;
 
 class Drupal
 {
@@ -143,8 +145,17 @@ class Drupal
                 $io->writeln("\r\033[K\033[1A\r<info>✔</info>");
                 $io->writeln('➤ Rebuilding container');
             }
+
+            // Fix an exception of FileCacheFactory not prefix not set when
+            // container is build and looks that as we depend on cache for
+            // AddServicesCompilerPass but container is not ready this prefix
+            // needs to be set manually to allow use of the cache files.
+            FileCacheFactory::setPrefix($this->drupalFinder->getDrupalRoot());
+
             $drupalKernel->invalidateContainer();
-            $drupalKernel->rebuildContainer();
+            // Looks that the boot process is handling an initializeContainer
+            // so looks that rebuildContainer repeats what we finally do in boot().
+            //$drupalKernel->rebuildContainer();
             $drupalKernel->boot();
 
             if ($debug) {

--- a/src/Bootstrap/DrupalKernel.php
+++ b/src/Bootstrap/DrupalKernel.php
@@ -26,7 +26,17 @@ class DrupalKernel extends DrupalKernelBase
         $kernel = new static($environment, $class_loader, $allow_dumping, $app_root);
         static::bootEnvironment($app_root);
         $kernel->initializeSettings($request);
-        $kernel->handle($request);
+        // Calling the request handle causes that a page request "/" is
+        // processed for any console execution even: help or --version and
+        // with sites that have globally displayed blocks contexts are not
+        // ready for blocks plugins so this causes lot of problems like:
+        // https://github.com/hechoendrupal/drupal-console/issues/3091 and
+        // https://github.com/hechoendrupal/drupal-console/issues/3553 Also
+        // handle does a initializeContainer which originally was invalidated
+        // and rebuild at Console Drupal Bootstrap. By disabling handle
+        // and processing the boot() at Bootstrap commands that do not
+        // depend on requests works well.
+        //$kernel->handle($request);
         return $kernel;
     }
 


### PR DESCRIPTION
Hi @jmolivas - @enzolutions, at Bluespark we have a project based on Drupal 8.3.7 and Drupal Console 1.0.0-beta4 that tried to upgrade to Drupal Console 1.0.2 but this caused a lot of fatal errors in our custom implementations of commands. I researched a bit of the existing issues and found that our error was very similar than https://github.com/hechoendrupal/drupal-console/issues/3091 so tried the workaround detailed on that issue to avoid usage of session but we found another fatal error that I reported at https://github.com/hechoendrupal/drupal-console/issues/3553

I tried to compare what have changed between the two versions to identify why this erros was not experimented in previous Drupal Console version and found that the main reason is the handle of the "/" default request which trigger hooks and globally display blocks access visibility rules among other things.

I reviewed all the Bootstrap process and started to experiment until have a bootstrap which don't caused those fatal exceptions. The main changes are:

- Avoid handle() of the request and only process the preHandle().
- Avoid to process build container on rebuildContainer and boot() to have only the initializeContainer on boot().
- Avoid use of container on compiler pass because that causes PHP warnings and in some cases also errors and just discovered that based on https://github.com/symfony/symfony/issues/22125#issuecomment-288734689 is recommended that container is not used at build phase, that error is exactly what I was experimenting in this project.

I have detailed with comments the reasons of all the changes so you can review, I was not really familiar with Drupal Kernel and Bootstrap process until this issue so I leave it to your expertise to decide what changes to preserve. I have tested multiples core and custom commands that are working properly. I would like to run tests for existing commands but couldn't found in documentation how to run tests in local. Can you guide me?

I hope this helps to guys that have been experimenting this weird problems when upgrading to last stable release and thanks for all your great job on the Drupal Console. I love it!