### PR TITLE
[console] Remove usage of expression builder on services registration.

### DIFF
--- a/config/services/rest.yml
+++ b/config/services/rest.yml
@@ -10,7 +10,6 @@ services:
       - '@?plugin.manager.rest'
       - '@authentication_collector'
       - '@config.factory'
-      - "@=container.hasParameter('serializer.formats') ? parameter('serializer.formats') : []"
       - '@entity.manager'
     tags:
       - { name: drupal.command }

--- a/services.yml
+++ b/services.yml
@@ -11,22 +11,22 @@ services:
     arguments: ['@app.root', '@entity_type.manager', '@http_client']
   console.create_node_data:
     class: Drupal\Console\Utils\Create\NodeData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@=service("console.drupal_api").getBundles()']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.create_comment_data:
     class: Drupal\Console\Utils\Create\CommentData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.create_term_data:
     class: Drupal\Console\Utils\Create\TermData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@=service("console.drupal_api").getVocabularies()']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.create_user_data:
     class: Drupal\Console\Utils\Create\UserData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@=service("console.drupal_api").getRoles()']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.create_role_data:
     class: Drupal\Console\Utils\Create\RoleData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.create_vocabulary_data:
     class: Drupal\Console\Utils\Create\VocabularyData
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@date.formatter', '@console.drupal_api']
   console.annotation_command_reader:
     class: Drupal\Console\Annotations\DrupalCommandAnnotationReader
   console.annotation_validator:

--- a/src/Command/Rest/EnableCommand.php
+++ b/src/Command/Rest/EnableCommand.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Command\Rest;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\rest\RestResourceConfigInterface;
 use Drupal\Console\Core\Style\DrupalStyle;
@@ -26,7 +26,7 @@ use Drupal\Core\Entity\EntityManager;
  *     extensionType = "module"
  * )
  */
-class EnableCommand extends Command
+class EnableCommand extends ContainerAwareCommand
 {
     use RestTrait;
 
@@ -46,44 +46,34 @@ class EnableCommand extends Command
     protected $configFactory;
 
     /**
-     * The available serialization formats.
-     *
-     * @var array
-     */
-    protected $formats;
-
-    /**
      * The entity manager.
      *
-     * @var \Drupal\Core\Entity\EntityManagerInterface
+     * @var EntityManager
      */
     protected $entityManager;
 
     /**
      * EnableCommand constructor.
      *
-     * @param ResourcePluginManager                      $pluginManagerRest
-     * @param AuthenticationCollector                    $authenticationCollector
-     * @param ConfigFactory                              $configFactory
-     * @param array                                      $formats
-     *   The available serialization formats.
-     * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+     * @param ResourcePluginManager   $pluginManagerRest
+     * @param AuthenticationCollector $authenticationCollector
+     * @param ConfigFactory           $configFactory
+     * @param EntityManager           $entity_manager
      *   The entity manager.
      */
     public function __construct(
         ResourcePluginManager $pluginManagerRest,
         AuthenticationCollector $authenticationCollector,
         ConfigFactory $configFactory,
-        array $formats,
         EntityManager $entity_manager
     ) {
         $this->pluginManagerRest = $pluginManagerRest;
         $this->authenticationCollector = $authenticationCollector;
         $this->configFactory = $configFactory;
-        $this->formats = $formats;
         $this->entityManager = $entity_manager;
         parent::__construct();
     }
+
 
     protected function configure()
     {
@@ -136,8 +126,9 @@ class EnableCommand extends Command
 
         $format = $io->choice(
             $this->trans('commands.rest.enable.arguments.formats'),
-            $this->formats
+            $this->container->getParameter('serializer.formats')
         );
+
         $io->writeln(
             $this->trans('commands.rest.enable.messages.selected-format') . ' ' . $format
         );

--- a/src/Command/Shared/RestTrait.php
+++ b/src/Command/Shared/RestTrait.php
@@ -21,7 +21,6 @@ trait RestTrait
 
         $resources = $this->pluginManagerRest->getDefinitions();
 
-
         $enabled_resources = array_combine(array_keys($config), array_keys($config));
         $available_resources = ['enabled' => [], 'disabled' => []];
 

--- a/src/Utils/Create/Base.php
+++ b/src/Utils/Create/Base.php
@@ -13,6 +13,7 @@ use Drupal\field\FieldConfigInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Console\Utils\DrupalApi;
 
 /**
  * Class ContentNode
@@ -21,20 +22,33 @@ use Drupal\Core\Datetime\DateFormatterInterface;
  */
 abstract class Base
 {
-    /* @var EntityTypeManagerInterface */
+    /**
+     * @var EntityTypeManagerInterface
+     */
     protected $entityTypeManager = null;
 
-    /* @var EntityFieldManagerInterface */
+    /**
+     * @var EntityFieldManagerInterface
+     */
     protected $entityFieldManager = null;
 
-    /* @var DateFormatterInterface */
+    /**
+     * @var DateFormatterInterface
+     */
     protected $dateFormatter = null;
 
     /* @var array */
     protected $users = [];
 
-    /* @var Random $random */
+    /**
+     * @var Random $random
+     */
     protected $random = null;
+
+    /**
+     * @var DrupalApi
+     */
+    protected $drupalApi;
 
     /**
      * ContentNode constructor.
@@ -42,15 +56,18 @@ abstract class Base
      * @param EntityTypeManagerInterface  $entityTypeManager
      * @param EntityFieldManagerInterface $entityFieldManager
      * @param DateFormatterInterface      $dateFormatter
+     * @param DrupalApi                   $drupalApi
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
         EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter
+        DateFormatterInterface $dateFormatter,
+        DrupalApi $drupalApi = null
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->entityFieldManager = $entityFieldManager;
         $this->dateFormatter = $dateFormatter;
+        $this->drupalApi = $drupalApi;
     }
 
     /**
@@ -82,8 +99,7 @@ abstract class Base
         /* @var \Drupal\field\FieldConfigInterface[] $fields */
         foreach ($fields as $field) {
             $fieldName = $field->getFieldStorageDefinition()->getName();
-            $cardinality = $field->getFieldStorageDefinition()->getCardinality(
-            );
+            $cardinality = $field->getFieldStorageDefinition()->getCardinality();
             if ($cardinality == FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED) {
                 $cardinality = rand(1, 5);
             }

--- a/src/Utils/Create/CommentData.php
+++ b/src/Utils/Create/CommentData.php
@@ -19,25 +19,6 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 class CommentData extends Base
 {
     /**
-     * Comments constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityTypeManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter
-    ) {
-        parent::__construct(
-            $entityTypeManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
-    /**
      * @param $nid
      * @param $limit
      * @param $titleWords

--- a/src/Utils/Create/NodeData.php
+++ b/src/Utils/Create/NodeData.php
@@ -19,31 +19,6 @@ use Drupal\Core\Language\LanguageInterface;
  */
 class NodeData extends Base
 {
-    /* @var array */
-    protected $bundles = [];
-
-    /**
-     * Nodes constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityTypeManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     * @param array                       $bundles
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter,
-        $bundles
-    ) {
-        $this->bundles = $bundles;
-        parent::__construct(
-            $entityTypeManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
     /**
      * @param $contentTypes
      * @param $limit
@@ -60,13 +35,13 @@ class NodeData extends Base
         $language = LanguageInterface::LANGCODE_NOT_SPECIFIED
     ) {
         $nodes = [];
+        $bundles = $this->drupalApi->getBundles();
         for ($i=0; $i<$limit; $i++) {
             $contentType = $contentTypes[array_rand($contentTypes)];
             $node = $this->entityTypeManager->getStorage('node')->create(
                 [
                     'nid' => null,
                     'type' => $contentType,
-
                     'created' => REQUEST_TIME - mt_rand(0, $timeRange),
                     'uid' => $this->getUserID(),
                     'title' => $this->getRandom()->sentences(mt_rand(1, $titleWords), true),
@@ -83,7 +58,7 @@ class NodeData extends Base
                 $node->save();
                 $nodes['success'][] = [
                     'nid' => $node->id(),
-                    'node_type' => $this->bundles[$contentType],
+                    'node_type' => $bundles[$contentType],
                     'title' => $node->getTitle(),
                     'created' => $this->dateFormatter->format(
                         $node->getCreatedTime(),
@@ -93,7 +68,7 @@ class NodeData extends Base
                 ];
             } catch (\Exception $error) {
                 $nodes['error'][] = [
-                    'node_type' =>  $this->bundles[$contentType],
+                    'node_type' =>  $bundles[$contentType],
                     'title' => $node->getTitle(),
                     'error' => $error->getMessage()
                 ];

--- a/src/Utils/Create/RoleData.php
+++ b/src/Utils/Create/RoleData.php
@@ -19,31 +19,9 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 class RoleData extends Base
 {
     /**
-     * Roles constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityTypeManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter
-    ) {
-        parent::__construct(
-            $entityTypeManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
-    /**
      * Create and returns an array of new Roles.
      *
-     * @param $roles
      * @param $limit
-     * @param $password
-     * @param $timeRange
      *
      * @return array
      */

--- a/src/Utils/Create/TermData.php
+++ b/src/Utils/Create/TermData.php
@@ -19,31 +19,6 @@ use Drupal\Core\Language\LanguageInterface;
  */
 class TermData extends Base
 {
-    /* @var array */
-    protected $vocabularies = [];
-
-    /**
-     * Terms constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityTypeManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     * @param array                       $vocabularies
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter,
-        $vocabularies
-    ) {
-        $this->vocabularies = $vocabularies;
-        parent::__construct(
-            $entityTypeManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
     /**
      * Create and returns an array of new Terms.
      *
@@ -58,6 +33,7 @@ class TermData extends Base
         $limit,
         $nameWords
     ) {
+        $siteVocabularies = $this->drupalApi->getVocabularies();
         $terms = [];
         for ($i=0; $i<$limit; $i++) {
             $vocabulary = $vocabularies[array_rand($vocabularies)];
@@ -77,12 +53,12 @@ class TermData extends Base
                 $term->save();
                 $terms['success'][] = [
                     'tid' => $term->id(),
-                    'vocabulary' => $this->vocabularies[$vocabulary],
+                    'vocabulary' => $siteVocabularies[$vocabulary],
                     'name' => $term->getName(),
                 ];
             } catch (\Exception $error) {
                 $terms['error'][] = [
-                    'vocabulary' => $this->vocabularies[$vocabulary],
+                    'vocabulary' => $siteVocabularies[$vocabulary],
                     'name' => $term->getName(),
                     'error' => $error->getMessage()
                 ];

--- a/src/Utils/Create/UserData.php
+++ b/src/Utils/Create/UserData.php
@@ -18,31 +18,6 @@ use Drupal\Core\Datetime\DateFormatterInterface;
  */
 class UserData extends Base
 {
-    /* @var array */
-    protected $roles = [];
-
-    /**
-     * Users constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityTypeManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     * @param array                       $roles
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter,
-        $roles
-    ) {
-        $this->roles = $roles;
-        parent::__construct(
-            $entityTypeManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
     /**
      * Create and returns an array of new Users.
      *
@@ -59,6 +34,7 @@ class UserData extends Base
         $password,
         $timeRange
     ) {
+        $siteRoles = $this->drupalApi->getRoles();
         $users = [];
         for ($i=0; $i<$limit; $i++) {
             $username = $this->getRandom()->word(mt_rand(6, 12));
@@ -79,7 +55,7 @@ class UserData extends Base
 
                 $userRoles = [];
                 foreach ($user->getRoles() as $userRole) {
-                    $userRoles[] = $this->roles[$userRole];
+                    $userRoles[] = $siteRoles[$userRole];
                 }
 
                 $users['success'][] = [

--- a/src/Utils/Create/VocabularyData.php
+++ b/src/Utils/Create/VocabularyData.php
@@ -21,25 +21,6 @@ use Drupal\Core\Language\LanguageInterface;
 class VocabularyData extends Base
 {
     /**
-     * Vocabularies constructor.
-     *
-     * @param EntityTypeManagerInterface  $entityManager
-     * @param EntityFieldManagerInterface $entityFieldManager
-     * @param DateFormatterInterface      $dateFormatter
-     */
-    public function __construct(
-        EntityTypeManagerInterface $entityManager,
-        EntityFieldManagerInterface $entityFieldManager,
-        DateFormatterInterface $dateFormatter
-    ) {
-        parent::__construct(
-            $entityManager,
-            $entityFieldManager,
-            $dateFormatter
-        );
-    }
-
-    /**
      * Create and returns an array of new Vocabularies.
      *
      * @param $limit


### PR DESCRIPTION
Since we are moving DrupalConsole services loading from `AddServicesCompilerPass`  to `DrupalKernel` class. Usage of Expression Language in service definition is no longer supported.

Error with current code-base.
![drupal-expression-builder](https://user-images.githubusercontent.com/366275/33158149-37399b2e-cfbc-11e7-912b-f81f7d8a707e.png)
