### PR TITLE
FIX #3556: Add urlRouteParameters function to the content entity class

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 {% if revisionable %}
 use Drupal\Core\Entity\RevisionableContentEntityBase;
+use Drupal\Core\Entity\RevisionableInterface;
 {% else %}
 use Drupal\Core\Entity\ContentEntityBase;
 {% endif %}
@@ -128,6 +129,22 @@ class {{ entity_class }} extends {% if revisionable %}RevisionableContentEntityB
     ];
   }
 {% if revisionable %}
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function urlRouteParameters($rel) {
+    $uri_route_parameters = parent::urlRouteParameters($rel);
+
+    if ($rel === 'revision_revert' && $this instanceof RevisionableInterface) {
+      $uri_route_parameters[$this->getEntityTypeId() . '_revision'] = $this->getRevisionId();
+    }
+    elseif ($rel === 'revision_delete' && $this instanceof RevisionableInterface) {
+      $uri_route_parameters[$this->getEntityTypeId() . '_revision'] = $this->getRevisionId();
+    }
+
+    return $uri_route_parameters;
+  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
From issue #3556:

> After Drupal update to 8.4, when trying to delete a revisionable entity created by drupal console the following exception is thrown:
> "Drupal\Core\Entity\EntityStorageException: Some mandatory parameters are missing ("console_entity_test_revision") to generate a URL for route "entity.console_entity_test.revision_revert". in Drupal\Core\Entity\Sql\SqlContentEntityStorage->delete() (line 753 of /var/www/html/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php)"

The issue was also reported (and closed) on drupal.org [0].

I just made a patch with the suggested code on both issues.



[0] https://www.drupal.org/project/drupal/issues/2919327
