### PR TITLE
ReMove default assignment alias in abstract class. The alias should b…

### DIFF
--- a/src/Command/Generate/FormBaseCommand.php
+++ b/src/Command/Generate/FormBaseCommand.php
@@ -13,6 +13,7 @@ class FormBaseCommand extends FormCommand
     {
         $this->setFormType('FormBase');
         $this->setCommandName('generate:form');
+        $this->setAliases(['gf']);
         parent::configure();
     }
 }

--- a/src/Command/Generate/FormCommand.php
+++ b/src/Command/Generate/FormCommand.php
@@ -192,7 +192,7 @@ abstract class FormCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.generate.form.options.menu-link-desc')
-            )->setAliases(['gf']);
+            );
     }
 
     /**


### PR DESCRIPTION
…e set in the classes which extend the FormCommand