### PR TITLE
[theme:*] Remove Drupal core code drupal_set_message.

### DIFF
--- a/src/Command/Theme/InstallCommand.php
+++ b/src/Command/Theme/InstallCommand.php
@@ -186,11 +186,10 @@ class InstallCommand extends Command
             } catch (UnmetDependenciesException $e) {
                 $io->error(
                     sprintf(
-                        $this->trans('commands.theme.install.messages.success'),
+                        $this->trans('commands.theme.install.messages.dependencies'),
                         $theme
                     )
                 );
-                drupal_set_message($e->getTranslatedMessage($this->getStringTranslation(), $theme), 'error');
 
                 return 1;
             }

--- a/src/Command/Theme/UninstallCommand.php
+++ b/src/Command/Theme/UninstallCommand.php
@@ -124,7 +124,7 @@ class UninstallCommand extends Command
         $this->themeHandler->refreshInfo();
         $theme = $input->getArgument('theme');
 
-        $themes  = $this->themeHandler->rebuildThemeData();
+        $themes = $this->themeHandler->rebuildThemeData();
         $themesAvailable = [];
         $themesUninstalled = [];
         $themesUnavailable = [];
@@ -188,7 +188,6 @@ class UninstallCommand extends Command
                         $e->getMessage()
                     )
                 );
-                drupal_set_message($e->getTranslatedMessage($this->getStringTranslation(), $theme), 'error');
 
                 return 1;
             }


### PR DESCRIPTION
1) Remove the code, which was copied from ThemeController.php of the Drupal for both **Install** and **Uninstall** commands
2) Update the message for Install command, when some dependencies are not met