### PR TITLE
Small bugfix for `update:execute`, removing extra unneeded parameter …

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -164,7 +164,6 @@ class ExecuteCommand extends Command
 
         try {
             $this->runUpdates(
-                $this->getIo(),
                 $updates
             );
 


### PR DESCRIPTION
…from `runUpdates`.

This should fix hechoendrupal/drupal-console#3756