### PR TITLE
[database:restore] #2174 Recreate database before importing the dump

### DIFF
--- a/config/services/database.yml
+++ b/config/services/database.yml
@@ -36,8 +36,3 @@ services:
     arguments: ['@database', '@date.formatter', '@entity_type.manager', '@string_translation']
     tags:
       - { name: drupal.command }
-  console.database_restore:
-    class: Drupal\Console\Command\Database\RestoreCommand
-    arguments: ['@app.root']
-    tags:
-      - { name: drupal.command }

--- a/src/Command/Database/RestoreCommand.php
+++ b/src/Command/Database/RestoreCommand.php
@@ -128,29 +128,28 @@ class RestoreCommand extends Command
         }
 
         foreach ($commands as $command) {
-          if ($learning) {
-            $this->getIo()->commentBlock($command);
-          }
+            if ($learning) {
+              $this->getIo()->commentBlock($command);
+            }
 
-          $processBuilder = new ProcessBuilder(['-v']);
-          $process = $processBuilder->getProcess();
-          $process->setWorkingDirectory($this->appRoot);
-          $process->setTty($input->isInteractive());
-          $process->setCommandLine($command);
-          $process->run();
+            $processBuilder = new ProcessBuilder(['-v']);
+            $process = $processBuilder->getProcess();
+            $process->setWorkingDirectory($this->appRoot);
+            $process->setTty($input->isInteractive());
+            $process->setCommandLine($command);
+            $process->run();
 
-          if (!$process->isSuccessful()) {
-            throw new \RuntimeException($process->getErrorOutput());
-          }
-
+            if (!$process->isSuccessful()) {
+              throw new \RuntimeException($process->getErrorOutput());
+            }
         }
 
         $this->getIo()->success(
-          sprintf(
-            '%s %s',
-            $this->trans('commands.database.restore.messages.success'),
-            $file
-          )
+            sprintf(
+              '%s %s',
+              $this->trans('commands.database.restore.messages.success'),
+              $file
+            )
         );
 
         return 0;

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -11,6 +11,11 @@ services:
     arguments: ['@app.root', '@console.configuration_manager']
     tags:
       - { name: drupal.command }
+  console.database_restore:
+    class: Drupal\Console\Command\Database\RestoreCommand
+    arguments: ['@app.root']
+    tags:
+      - { name: drupal.command }
   console.site_install:
     class: Drupal\Console\Command\Site\InstallCommand
     arguments: ['@console.extension_manager', '@console.site', '@console.configuration_manager', '@app.root']


### PR DESCRIPTION
This PR fixes the issue #2174
I don't think we need a --replace option. The DROP/CREATE needs to happen every time.
