### PR TITLE
[template] Replace deprecated drupal_set_message

### DIFF
--- a/templates/module/post-update.php.twig
+++ b/templates/module/post-update.php.twig
@@ -6,7 +6,7 @@
  * Implements hook_post_update_NAME() on Module {{ module }} Post Update {{ post_update_name }}.
  */
 function {{ module }}_post_update_{{ post_update_name }}(&$sandbox) {
-    drupal_set_message('Module {{ module }} Post Update # {{ post_update_name }} () was executed successfully.');
+    \Drupal::messenger()->addMessage('Module {{ module }} Post Update # {{ post_update_name }} () was executed successfully.');
 }
 
 {% endblock %}

--- a/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
@@ -116,7 +116,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
     $this->{{ entity_class }}Storage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('{{ label }}: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    \Drupal::messenger()->addMessage(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.{{ entity_name }}.canonical',
        ['{{ entity_name }}' => $this->revision->id()]

--- a/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
@@ -129,7 +129,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
     $this->revision->save();
 
     $this->logger('content')->notice('{{ label }}: reverted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('{{ label }} %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
+    \Drupal::messenger()->addMessage(t('{{ label }} %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
     $form_state->setRedirect(
       'entity.{{ entity_name }}.version_history',
       ['{{ entity_name }}' => $this->revision->id()]

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -68,13 +68,13 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label {{ label }}.', [
+        \Drupal::messenger()->addMessage($this->t('Created the %label {{ label }}.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label {{ label }}.', [
+        \Drupal::messenger()->addMessage($this->t('Saved the %label {{ label }}.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/templates/module/src/Form/entity-delete.php.twig
+++ b/templates/module/src/Form/entity-delete.php.twig
@@ -47,7 +47,7 @@ class {{ entity_class }}DeleteForm extends EntityConfirmFormBase {% endblock %}
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
 
-    drupal_set_message(
+    \Drupal::messenger()->addMessage(
       $this->t('content @type: deleted @label.',
         [
           '@type' => $this->entity->bundle(),

--- a/templates/module/src/Form/entity.php.twig
+++ b/templates/module/src/Form/entity.php.twig
@@ -58,13 +58,13 @@ class {{ entity_class }}Form extends EntityForm {% endblock %}
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label {{ label }}.', [
+        \Drupal::messenger()->addMessage($this->t('Created the %label {{ label }}.', [
           '%label' => ${{ entity_name | machine_name }}->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label {{ label }}.', [
+        \Drupal::messenger()->addMessage($this->t('Saved the %label {{ label }}.', [
           '%label' => ${{ entity_name | machine_name }}->label(),
         ]));
     }

--- a/templates/module/src/Form/form-alter.php.twig
+++ b/templates/module/src/Form/form-alter.php.twig
@@ -12,7 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 {% endif %}
  */
 function {{ module }}_form_{{ form_id }}_alter(&$form, FormStateInterface $form_state) {
-    drupal_set_message('{{ module }}_form_{{ form_id }}_alter() executed.');
+    \Drupal::messenger()->addMessage('{{ module }}_form_{{ form_id }}_alter() executed.');
 {% else %}
 /**
  * Implements hook_form_alter() on behalf of {{ module }}.module.
@@ -20,7 +20,7 @@ function {{ module }}_form_{{ form_id }}_alter(&$form, FormStateInterface $form_
 function {{ module }}_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     // Change form id here
     if ($form_id == 'form_test_alter_form') {
-        drupal_set_message('form_test_form_alter() executed.');
+        \Drupal::messenger()->addMessage('form_test_form_alter() executed.');
 {% endif %}
 
 {%- if metadata.unset -%}

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -108,7 +108,7 @@ class {{ class_name }} extends FormBase {% endblock %}
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Display result.
     foreach ($form_state->getValues() as $key => $value) {
-      drupal_set_message($key . ': ' . $value);
+      \Drupal::messenger()->addMessage($key . ': ' . $value);
     }
 
   }

--- a/templates/module/src/cache-context.php.twig
+++ b/templates/module/src/cache-context.php.twig
@@ -35,7 +35,7 @@ class {{ class }} implements CacheContextInterface {% endblock %}
   * {@inheritdoc}
   */
   public static function getLabel() {
-    drupal_set_message('Lable of cache context');
+    \Drupal::messenger()->addMessage('Lable of cache context');
   }
 
   /**

--- a/templates/module/src/event-subscriber.php.twig
+++ b/templates/module/src/event-subscriber.php.twig
@@ -50,7 +50,7 @@ class {{ class }} implements EventSubscriberInterface {% endblock %}
    * @param GetResponseEvent $event
    */
   public function {{ callback }}(Event $event) {
-    drupal_set_message('Event {{ event_name }} thrown by Subscriber in module {{ module }}.', 'status', TRUE);
+    \Drupal::messenger()->addMessage('Event {{ event_name }} thrown by Subscriber in module {{ module }}.', 'status', TRUE);
   }
 {% endfor %}
 {% endblock %}

--- a/templates/module/update.php.twig
+++ b/templates/module/update.php.twig
@@ -6,7 +6,7 @@
  * Implements hook_update_N() on Module {{ module }} Update # {{ update_number }}.
  */
 function {{ module }}_update_{{ update_number }}(&$sandbox) {
-    drupal_set_message('Module {{ module }} Update # {{ update_number }} () was executed successfully.');
+    \Drupal::messenger()->addMessage('Module {{ module }} Update # {{ update_number }} () was executed successfully.');
 }
 
 {% endblock %}


### PR DESCRIPTION
drupal_set_message is marked as deprecated and will be removed in drupal 9.

We should use best practices in the templates and fix deprecation issues as fast as possible to keep the effort needed to port this project to drupal 9 minimal.