### PR TITLE
[multisite:new] fix so that multi site command uses uri argument

### DIFF
--- a/src/Command/Multisite/NewCommand.php
+++ b/src/Command/Multisite/NewCommand.php
@@ -154,7 +154,7 @@ class NewCommand extends Command
             throw new FileNotFoundException($this->trans('commands.multisite.new.errors.sites-missing'));
         }
 
-        $sites_file_contents .= "\n\$sites['$this->directory'] = '$this->directory';";
+        $sites_file_contents .= "\n\$sites['$uri'] = '$this->directory';";
 
         try {
             $this->fs->dumpFile($this->appRoot . '/sites/sites.php', $sites_file_contents);


### PR DESCRIPTION
## Problem/Motivation
When running the `drupal multisite:new ` the second argument `uri` is never used and the `directory` argument is used in its place making it impossible to take full advantage of all the functionality in the `sites.php` file that this command writes to

## How to reproduce
run `Drupal multisite:new new-site http://new-site.example.com`
In `sites.php` you will see `$sites['new-site'] = 'new-site';`
When the final result should actually be `$sites['http://new-site.example.com'] = 'new-site';`

## Solution
The solution in this PR fixes the issues