### PR TITLE
allow alchemy/zippy version to go above 0.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "alchemy/zippy": "0.4.3",
+        "alchemy/zippy": "^0.4.3",
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",


### PR DESCRIPTION
This addresses the following issue: #3845 

Unless there was a reason to lock to a specific version, then ignore.