### PR TITLE
Fix coding standards for generate:form command.

### DIFF
--- a/src/Generator/FormGenerator.php
+++ b/src/Generator/FormGenerator.php
@@ -80,7 +80,7 @@ class FormGenerator extends Generator
             $moduleInstance->getFormPath() . '/' . $class_name . '.php',
             $parameters
         );
-        
+
         // Render defaults YML file.
         if ($config_file == true) {
             $this->renderFile(

--- a/templates/module/routing-form.yml.twig
+++ b/templates/module/routing-form.yml.twig
@@ -13,6 +13,5 @@
 {% else %}
   requirements:
     _access: 'TRUE'
-  {% endif %}
 {% endif %}
-
+{% endif %}

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -21,8 +21,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Class {{ class_name }}.
  */
 class {{ class_name }} extends FormBase {% endblock %}
+
 {% block class_construct %}
 {% if services is not empty %}
+
   /**
    * Constructs a new {{ class_name }} object.
    */
@@ -37,12 +39,14 @@ class {{ class_name }} extends FormBase {% endblock %}
 
 {% block class_create %}
 {% if services is not empty %}
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container) {
     return new static(
 {{ serviceClassInjection(services) }}
     );
   }
-
 {% endif %}
 {% endblock %}
 
@@ -99,6 +103,9 @@ class {{ class_name }} extends FormBase {% endblock %}
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
+    foreach ($form_state->getValues() as $key => $value) {
+      // @TODO: Validate fields.
+    }
     parent::validateForm($form, $form_state);
   }
 


### PR DESCRIPTION
Make the generated code comply with Coding Standards

How to test:
- Generate module named "mymodule"
- Generate form with this command: `drupal generate:form  --module="mymodule" --class="DefaultForm" --form-id="default_form" --services='current_user' --config-file --inputs='"name":"text_field", "type":"textfield", "label":"text field", "options":"", "description":"", "maxlength":"64", "size":"64", "default_value":"", "weight":"0", "fieldset":""' --path="/mymodule/form/default" --learning --uri="http://default" --no-interaction`
- Evaluate coding standards (ex. `phpcs --standard=Drupal web/modules/custom/mymodule/*`)
- It should pass