### PR TITLE
config:import changed to support config.storage.sync service for default instance 

### DIFF
--- a/src/Command/Config/ImportCommand.php
+++ b/src/Command/Config/ImportCommand.php
@@ -88,14 +88,10 @@ class ImportCommand extends Command
         $skipUuid = $input->getOption('skip-uuid');
 
         if ($directory) {
-            $configSyncDir = $directory;
+            $source_storage = new FileStorage($directory);
         } else {
-            $configSyncDir = config_get_config_directory(
-                CONFIG_SYNC_DIRECTORY
-            );
+            $source_storage = \Drupal::service('config.storage.sync');
         }
-
-        $source_storage = new FileStorage($configSyncDir);
 
         $storageComparer = '\Drupal\Core\Config\StorageComparer';
         if ($skipUuid) {


### PR DESCRIPTION
Reason for this pull request:

I'm trying to use the drupal/config_ignore module, which in turn relies on drupal/config_filter module to maintain a separate local dev/staging/prod configuration. Config_ignore has changed how it works internally and relies on config_filter to provide the filtering mechanism. config_filter in turn decorates the config.storage.staging/sync service in order to inject it's own FilteredStorage class to handle the filtering. But the current Drupal console class ```src/Command/Config/ImportCommand.php``` creates a FileStorage instance directly inside it's execute command, instead of relying on the instance returned from ```\Drupal::service('config.storage.sync')```. Thus the decorated class is never made available to the import command and the import filtering does not work. 

This pull request changes the ImportCommand so that in the default case (no ```--directory``` option provided) it uses the ```FileStorage``` instance from the service container instead of creating it's own local instance. AFAIK this does not break anything, but adds the possibility to override the filestorage by using decorators, like what the config_filter module does.