### PR TITLE
[site:install] Implement db_url to install

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -85,6 +85,12 @@ class InstallCommand extends ContainerAwareCommand
                 $this->trans('commands.site.install.arguments.langcode')
             )
             ->addOption(
+                'db-url',
+                null,
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.site.install.arguments.db-url')
+            )
+            ->addOption(
                 'db-type',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -222,8 +228,14 @@ class InstallCommand extends ContainerAwareCommand
         // Use default database setting if is available
         $database = Database::getConnectionInfo();
         if (empty($database['default'])) {
+
+            // --db-url option
+            $db_url = $input->getOption('db-url');
+            $valuesFromUrl = parse_url($db_url);
+
+            $input->setOption('db-prefix', '');
             // --db-type option
-            $dbType = $input->getOption('db-type');
+            $dbType = $db_url?$valuesFromUrl['scheme']:$input->getOption('db-type');
             if (!$dbType) {
                 $databases = $this->site->getDatabaseTypes();
                 $dbType = $this->getIo()->choice(
@@ -236,64 +248,66 @@ class InstallCommand extends ContainerAwareCommand
                         $dbType = $dbIndex;
                     }
                 }
-
-                $input->setOption('db-type', $dbType);
             }
+            $input->setOption('db-type', $dbType);
 
             if ($dbType === 'sqlite') {
+                $valuesFromUrl = explode('//', $db_url);
                 // --db-file option
-                $dbFile = $input->getOption('db-file');
+                $dbFile = $db_url?$valuesFromUrl[1]:$input->getOption('db-file');
                 if (!$dbFile) {
                     $dbFile = $this->getIo()->ask(
                         $this->trans('commands.migrate.execute.questions.db-file'),
                         'sites/default/files/.ht.sqlite'
                     );
-                    $input->setOption('db-file', $dbFile);
                 }
+                $input->setOption('db-file', $dbFile);
             } else {
                 // --db-host option
-                $dbHost = $input->getOption('db-host');
+                $dbHost = $db_url?$valuesFromUrl['host']:$input->getOption('db-host');
                 if (!$dbHost) {
                     $dbHost = $this->dbHostQuestion();
-                    $input->setOption('db-host', $dbHost);
                 }
+                $input->setOption('db-host', $dbHost);
 
                 // --db-name option
-                $dbName = $input->getOption('db-name');
+                $dbName = $db_url?ltrim($valuesFromUrl['path'], "/"):$input->getOption('db-name');
                 if (!$dbName) {
                     $dbName = $this->dbNameQuestion();
-                    $input->setOption('db-name', $dbName);
                 }
+                $input->setOption('db-name', $dbName);
 
                 // --db-user option
-                $dbUser = $input->getOption('db-user');
+                $dbUser = $db_url?$valuesFromUrl['user']:$input->getOption('db-user');
                 if (!$dbUser) {
                     $dbUser = $this->dbUserQuestion();
-                    $input->setOption('db-user', $dbUser);
                 }
+                $input->setOption('db-user', $dbUser);
+
 
                 // --db-pass option
-                $dbPass = $input->getOption('db-pass');
+                $dbPass = $db_url?$valuesFromUrl['pass']:$input->getOption('db-pass');
                 if (!$dbPass) {
                     $dbPass = $this->dbPassQuestion();
-                    $input->setOption('db-pass', $dbPass);
                 }
+                $input->setOption('db-pass', $dbPass);
 
                 // --db-port prefix
-                $dbPort = $input->getOption('db-port');
+                $dbPort = $db_url?$valuesFromUrl['port']:$input->getOption('db-port');
                 if (!$dbPort) {
                     $dbPort = $this->dbPortQuestion();
-                    $input->setOption('db-port', $dbPort);
                 }
+                $input->setOption('db-port', $dbPort);
             }
 
             // --db-prefix
             $dbPrefix = $input->getOption('db-prefix');
             if (!$dbPrefix) {
                 $dbPrefix = $this->dbPrefixQuestion();
-                $input->setOption('db-prefix', $dbPrefix);
             }
+            $input->setOption('db-prefix', $dbPrefix);
         } else {
+
             $input->setOption('db-type', $database['default']['driver']);
             $input->setOption('db-host', $database['default']['host']);
             $input->setOption('db-name', $database['default']['database']);
@@ -396,10 +410,10 @@ class InstallCommand extends ContainerAwareCommand
 
         if ($dbType === 'sqlite') {
             $database = [
-              'database' => $dbFile,
-              'prefix' => $dbPrefix,
-              'namespace' => $databases[$dbType]['namespace'],
-              'driver' => $dbType,
+                'database' => $dbFile,
+                'prefix' => $dbPrefix,
+                'namespace' => $databases[$dbType]['namespace'],
+                'driver' => $dbType,
             ];
 
             if ($force) {
@@ -408,14 +422,14 @@ class InstallCommand extends ContainerAwareCommand
             }
         } else {
             $database = [
-              'database' => $dbName,
-              'username' => $dbUser,
-              'password' => $dbPass,
-              'prefix' => $dbPrefix,
-              'port' => $dbPort,
-              'host' => $dbHost,
-              'namespace' => $databases[$dbType]['namespace'],
-              'driver' => $dbType,
+                'database' => $dbName,
+                'username' => $dbUser,
+                'password' => $dbPass,
+                'prefix' => $dbPrefix,
+                'port' => $dbPort,
+                'host' => $dbHost,
+                'namespace' => $databases[$dbType]['namespace'],
+                'driver' => $dbType,
             ];
 
             if ($force && Database::isActiveConnection()) {

--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -406,6 +406,22 @@ class InstallCommand extends ContainerAwareCommand
         $dbPort = $input->getOption('db-port')?:'3306';
         $force = $input->getOption('force');
 
+        //Check if there is a url to db connection
+        $db_url = $input->getOption('db-url');
+        if ($db_url) {
+            $valuesFromUrl = parse_url($db_url);
+            $dbType = $valuesFromUrl['scheme'];
+            if($dbType === 'sqlite'){
+                $valuesFromUrl = explode('//', $db_url);
+                $dbFile = $valuesFromUrl[1];
+            } else {
+                $dbHost = $valuesFromUrl['host'];
+                $dbName = ltrim($valuesFromUrl['path'], "/");
+                $dbUser = $valuesFromUrl['user'];
+                $dbPass = $valuesFromUrl['pass'];
+            }
+        }
+
         $databases = $this->site->getDatabaseTypes();
 
         if ($dbType === 'sqlite') {


### PR DESCRIPTION
The Pr allow install a site using a db url, avoiding using the options.

Example
```
drupal site:install  standard mysql://dbUser:dbPass@dbHost/dbName --no-interaction
```

![image](https://user-images.githubusercontent.com/8105777/57879035-baac3500-77d8-11e9-9ef2-6d4fc6f9e96d.png)
