### PR TITLE
standard: update alchemy-zippy dep version due its outdated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "alchemy/zippy": "0.4.3",
+        "alchemy/zippy": "~0.4",
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",


### PR DESCRIPTION
alchemy/zippy dep version 0.4.3 is outdated, there is newer version