### PR TITLE
fix: use user supplied uri back

### DIFF
--- a/src/Command/Multisite/NewCommand.php
+++ b/src/Command/Multisite/NewCommand.php
@@ -154,7 +154,7 @@ class NewCommand extends Command
             throw new FileNotFoundException($this->trans('commands.multisite.new.errors.sites-missing'));
         }
 
-        $sites_file_contents .= "\n\$sites['$this->directory'] = '$this->directory';";
+        $sites_file_contents .= "\n\$sites['$uri'] = '$this->directory';";
 
         try {
             $this->fs->dumpFile($this->appRoot . '/sites/sites.php', $sites_file_contents);


### PR DESCRIPTION
## :question: What does this PR do ?

It kinda reverts #3232 (#3197) and follows on #3508 .

It is my conviction that a user of the `multisite:new` command should know the different ways an site alias can be written.

Those different ways are listed in the `sites/example.sites.php` of a regular **drupal 8** installation.