### PR TITLE
Ask for db prefix only if it is not explicitly set (#3930)

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -287,9 +287,9 @@ class InstallCommand extends ContainerAwareCommand
                 }
             }
 
-            // --db-prefix
+            // --db-prefix option
             $dbPrefix = $input->getOption('db-prefix');
-            if (!$dbPrefix) {
+            if ($dbPrefix === null) {
                 $dbPrefix = $this->dbPrefixQuestion();
                 $input->setOption('db-prefix', $dbPrefix);
             }


### PR DESCRIPTION
This should address the issue mentioned in #3930 

Instead of implicit type casting by means of the `!` operator we check if the value is set but empty (no action) or not set (ask)