### PR TITLE
Changes constructor type signatures (#3919)

### DIFF
--- a/src/Command/Debug/EntityCommand.php
+++ b/src/Command/Debug/EntityCommand.php
@@ -10,13 +10,13 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
-use Drupal\Core\Entity\EntityTypeRepository;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 class EntityCommand extends Command
 {
     /**
-     * @var EntityTypeRepository
+     * @var EntityTypeRepositoryInterface
      */
     protected $entityTypeRepository;
 
@@ -28,11 +28,11 @@ class EntityCommand extends Command
     /**
      * EntityCommand constructor.
      *
-     * @param EntityTypeRepository       $entityTypeRepository
-     * @param EntityTypeManagerInterface $entityTypeManager
+     * @param EntityTypeRepositoryInterface $entityTypeRepository
+     * @param EntityTypeManagerInterface    $entityTypeManager
      */
     public function __construct(
-        EntityTypeRepository $entityTypeRepository,
+        EntityTypeRepositoryInterface $entityTypeRepository,
         EntityTypeManagerInterface $entityTypeManager
     ) {
         $this->entityTypeRepository = $entityTypeRepository;

--- a/src/Command/Entity/DeleteCommand.php
+++ b/src/Command/Entity/DeleteCommand.php
@@ -11,13 +11,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
-use Drupal\Core\Entity\EntityTypeRepository;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 class DeleteCommand extends Command
 {
     /**
-     * @var EntityTypeRepository
+     * @var EntityTypeRepositoryInterface
      */
     protected $entityTypeRepository;
 
@@ -29,11 +29,11 @@ class DeleteCommand extends Command
     /**
      * DeleteCommand constructor.
      *
-     * @param EntityTypeRepository       $entityTypeRepository
-     * @param EntityTypeManagerInterface $entityTypeManager
+     * @param EntityTypeRepositoryInterface $entityTypeRepository
+     * @param EntityTypeManagerInterface    $entityTypeManager
      */
     public function __construct(
-        EntityTypeRepository $entityTypeRepository,
+        EntityTypeRepositoryInterface $entityTypeRepository,
         EntityTypeManagerInterface $entityTypeManager
     ) {
         $this->entityTypeRepository = $entityTypeRepository;

--- a/src/Command/Generate/PluginConditionCommand.php
+++ b/src/Command/Generate/PluginConditionCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
-use Drupal\Core\Entity\EntityTypeRepository;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Console\Generator\PluginConditionGenerator;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
@@ -59,18 +59,18 @@ class PluginConditionCommand extends Command
     /**
      * PluginConditionCommand constructor.
      *
-     * @param Manager                  $extensionManager
-     * @param PluginConditionGenerator $generator
-     * @param ChainQueue               $chainQueue
-     * @param EntityTypeRepository     $entitytyperepository
-     * @param StringConverter          $stringConverter
-     * @param Validator                $validator
+     * @param Manager                       $extensionManager
+     * @param PluginConditionGenerator      $generator
+     * @param ChainQueue                    $chainQueue
+     * @param EntityTypeRepositoryInterface $entitytyperepository
+     * @param StringConverter               $stringConverter
+     * @param Validator                     $validator
      */
     public function __construct(
         Manager $extensionManager,
         PluginConditionGenerator $generator,
         ChainQueue $chainQueue,
-        EntityTypeRepository $entitytyperepository,
+        EntityTypeRepositoryInterface $entitytyperepository,
         StringConverter $stringConverter,
         Validator $validator
     ) {


### PR DESCRIPTION
Changes the type signatures for a few classes to use interfaces instead of classes.

Associated issue: https://github.com/hechoendrupal/drupal-console/issues/3919