### PR TITLE
[generate:plugin:queue] Create new command to generate QueueWorker

### DIFF
--- a/config/services/generate.yml
+++ b/config/services/generate.yml
@@ -144,6 +144,11 @@ services:
     arguments: ['@console.extension_manager', '@console.plugin_views_field_generator', '@console.site','@console.string_converter', '@console.validator', '@console.chain_queue']
     tags:
        - { name: drupal.command }
+  console.generate_plugin_queue:
+    class: Drupal\Console\Command\Generate\QueueWorkerCommand
+    arguments: ['@console.plugin_queue_generator', '@console.extension_manager', '@console.validator', '@console.string_converter']
+    tags:
+      - { name: drupal.command }
   console.generate_post_update:
     class: Drupal\Console\Command\Generate\PostUpdateCommand
     arguments: ['@console.extension_manager', '@console.post_update_generator', '@console.site', '@console.validator','@console.chain_queue']

--- a/config/services/generate.yml
+++ b/config/services/generate.yml
@@ -146,7 +146,7 @@ services:
        - { name: drupal.command }
   console.generate_plugin_queue:
     class: Drupal\Console\Command\Generate\PluginQueueWorkerCommand
-    arguments: ['@console.plugin_queue_generator','@console.extension_manager','@console.validator','@console.string_converter','@console.chain_queue']
+    arguments: ['@console.plugin_queue_generator','@console.validator','@console.string_converter','@console.chain_queue']
     tags:
       - { name: drupal.command }
   console.generate_post_update:

--- a/config/services/generate.yml
+++ b/config/services/generate.yml
@@ -145,8 +145,8 @@ services:
     tags:
        - { name: drupal.command }
   console.generate_plugin_queue:
-    class: Drupal\Console\Command\Generate\QueueWorkerCommand
-    arguments: ['@console.plugin_queue_generator', '@console.extension_manager', '@console.validator', '@console.string_converter']
+    class: Drupal\Console\Command\Generate\PluginQueueWorkerCommand
+    arguments: ['@console.plugin_queue_generator','@console.extension_manager','@console.validator','@console.string_converter','@console.chain_queue']
     tags:
       - { name: drupal.command }
   console.generate_post_update:

--- a/config/services/generator.yml
+++ b/config/services/generator.yml
@@ -146,6 +146,11 @@ services:
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }
+  console.plugin_queue_generator:
+    class: Drupal\Console\Generator\QueueWorkerGenerator
+    arguments: ['@console.extension_manager']
+    tags:
+      - { name: drupal.generator }
   console.route_subscriber_generator:
     class: Drupal\Console\Generator\RouteSubscriberGenerator
     arguments: ['@console.extension_manager']

--- a/config/services/generator.yml
+++ b/config/services/generator.yml
@@ -147,7 +147,7 @@ services:
     tags:
       - { name: drupal.generator }
   console.plugin_queue_generator:
-    class: Drupal\Console\Generator\QueueWorkerGenerator
+    class: Drupal\Console\Generator\PluginQueueWorkerGenerator
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }

--- a/src/Command/Generate/PluginQueueWorkerCommand.php
+++ b/src/Command/Generate/PluginQueueWorkerCommand.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\Console\Command\Generate\PluginQueueWorkerCommand.
- */
-
 namespace Drupal\Console\Command\Generate;
 
 use Drupal\Console\Core\Command\Command;

--- a/src/Command/Generate/PluginQueueWorkerCommand.php
+++ b/src/Command/Generate/PluginQueueWorkerCommand.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Generate\PluginQueueWorkerCommand.
+ */
+
+namespace Drupal\Console\Command\Generate;
+
+use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Utils\ChainQueue;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Console\Core\Generator\GeneratorInterface;
+use Drupal\Console\Command\Shared\ModuleTrait;
+use Drupal\Console\Command\Shared\ConfirmationTrait;
+use Symfony\Component\Console\Input\InputOption;
+use Drupal\Console\Extension\Manager;
+use Drupal\Console\Utils\Validator;
+use Drupal\Console\Core\Utils\StringConverter;
+
+/**
+ * Class PluginQueueWorkerCommand.
+ *
+ * @package Drupal\Console\Command\Generate
+ */
+class PluginQueueWorkerCommand extends Command {
+
+  use ModuleTrait;
+  use ConfirmationTrait;
+
+  /**
+   * Drupal\Console\Core\Generator\GeneratorInterface definition.
+   *
+   * @var \Drupal\Console\Core\Generator\GeneratorInterface
+   */
+  protected $generator;
+
+  /**
+   * Extension Manager.
+   *
+   * @var \Drupal\Console\Extension\Manager
+   */
+  protected $extensionManager;
+
+  /**
+   * Validator.
+   *
+   * @var \Drupal\Console\Utils\Validator
+   */
+  protected $validator;
+
+  /**
+   * String converter.
+   *
+   * @var \Drupal\Console\Core\Utils\StringConverter
+   */
+  protected $stringConverter;
+
+  /**
+   * Chain queue.
+   *
+   * @var \Drupal\Console\Core\Utils\ChainQueue
+   */
+  protected $chainQueue;
+
+
+  /**
+   * PluginQueueWorkerCommand constructor.
+   *
+   * @param \Drupal\Console\Core\Generator\GeneratorInterface $queue_generator
+   *   Queue Generator.
+   * @param \Drupal\Console\Extension\Manager $extensionManager
+   *   Extension manager.
+   * @param \Drupal\Console\Utils\Validator $validator
+   *   Validator.
+   * @param \Drupal\Console\Core\Utils\StringConverter $stringConverter
+   *   String Converter.
+   * @param \Drupal\Console\Core\Utils\ChainQueue $chainQueue
+   *   Chain queue.
+   */
+  public function __construct(
+    GeneratorInterface $queue_generator,
+    Manager $extensionManager,
+    Validator $validator,
+    StringConverter $stringConverter,
+    ChainQueue $chainQueue
+  ) {
+    $this->generator = $queue_generator;
+    $this->extensionManager = $extensionManager;
+    $this->validator = $validator;
+    $this->stringConverter = $stringConverter;
+    $this->chainQueue = $chainQueue;
+    parent::__construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('generate:plugin:queue')
+      ->setDescription($this->trans('commands.generate.plugin.queue.description'))
+      ->setHelp($this->trans('commands.generate.plugin.queue.help'))
+      ->addOption(
+          'module',
+          NULL,
+          InputOption::VALUE_REQUIRED,
+          $this->trans('commands.generate.plugin.queue.options.module')
+      )
+      ->addOption(
+          'queue-class',
+          NULL,
+          InputOption::VALUE_REQUIRED,
+          $this->trans('commands.generate.plugin.queue.options.queue-class')
+      )
+      ->addOption(
+          'plugin-id',
+          NULL,
+          InputOption::VALUE_REQUIRED,
+          $this->trans('commands.generate.plugin.queue.options.plugin-id')
+      )
+      ->addOption(
+          'cron-time',
+          NULL,
+          InputOption::VALUE_REQUIRED,
+          $this->trans('commands.generate.plugin.queue.options.cron-time')
+      )
+      ->addOption(
+          'label',
+          NULL,
+          InputOption::VALUE_REQUIRED,
+          $this->trans('commands.generate.plugin.queue.options.label')
+      )
+      ->setAliases(['gpqueue']);
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function interact(InputInterface $input, OutputInterface $output) {
+    // --module option.
+    $this->getModuleOption();
+
+    // --queue-class option.
+    $queue_class = $input->getOption('queue-class');
+    if (!$queue_class) {
+      $queue_class = $this->getIo()->ask(
+            $this->trans('commands.generate.plugin.queue.questions.queue-class'),
+            'ExampleQueue',
+            function ($queue_class) {
+              return $this->validator->validateClassName($queue_class);
+            }
+        );
+      $input->setOption('queue-class', $queue_class);
+    }
+
+    // --plugin-id option.
+    $plugin_id = $input->getOption('plugin-id');
+    if (!$plugin_id) {
+      $plugin_id = $this->getIo()->ask(
+          $this->trans('commands.generate.plugin.queue.questions.plugin-id'),
+          'example_plugin_id',
+          function ($plugin_id) {
+            return $this->stringConverter->camelCaseToUnderscore($plugin_id);
+          }
+      );
+      $input->setOption('plugin-id', $plugin_id);
+    }
+
+    // --cron-time option.
+    $cron_time = $input->getOption('cron-time');
+    if (!$cron_time) {
+      $cron_time = $this->getIo()->ask(
+          $this->trans('commands.generate.plugin.queue.questions.cron-time'),
+          30
+      );
+      $input->setOption('cron-time', $cron_time);
+    }
+
+    // --label option.
+    $label = $input->getOption('label');
+    if (!$label) {
+      $label = $this->getIo()->ask(
+          $this->trans('commands.generate.plugin.queue.questions.label'),
+          'Queue description.'
+      );
+      $input->setOption('label', $label);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    // @see use Drupal\Console\Command\Shared\ConfirmationTrait::confirmOperation
+    if (!$this->confirmOperation()) {
+      return 1;
+    }
+    $module = $input->getOption('module');
+    $queue_class = $input->getOption('queue-class');
+    $plugin_id = $input->getOption('plugin-id');
+    $cron_time = $input->getOption('cron-time');
+    $label = $input->getOption('label');
+    $this->generator->generate([
+      'module' => $module,
+      'class_name' => $queue_class,
+      'plugin_id' => $plugin_id,
+      'cron_time' => $cron_time,
+      'label' => $label,
+    ]);
+
+    $this->chainQueue->addCommand('cache:rebuild', ['cache' => 'discovery']);
+
+    return 0;
+  }
+
+}

--- a/src/Command/Generate/PluginQueueWorkerCommand.php
+++ b/src/Command/Generate/PluginQueueWorkerCommand.php
@@ -109,10 +109,10 @@ class PluginQueueWorkerCommand extends Command {
           $this->trans('commands.generate.plugin.queue.options.module')
       )
       ->addOption(
-          'queue-class',
+          'class',
           NULL,
           InputOption::VALUE_REQUIRED,
-          $this->trans('commands.generate.plugin.queue.options.queue-class')
+          $this->trans('commands.generate.plugin.queue.options.class')
       )
       ->addOption(
           'plugin-id',
@@ -143,17 +143,17 @@ class PluginQueueWorkerCommand extends Command {
     // --module option.
     $this->getModuleOption();
 
-    // --queue-class option.
-    $queue_class = $input->getOption('queue-class');
+    // --class option.
+    $queue_class = $input->getOption('class');
     if (!$queue_class) {
       $queue_class = $this->getIo()->ask(
-            $this->trans('commands.generate.plugin.queue.questions.queue-class'),
+            $this->trans('commands.generate.plugin.queue.questions.class'),
             'ExampleQueue',
             function ($queue_class) {
               return $this->validator->validateClassName($queue_class);
             }
         );
-      $input->setOption('queue-class', $queue_class);
+      $input->setOption('class', $queue_class);
     }
 
     // --plugin-id option.
@@ -199,7 +199,7 @@ class PluginQueueWorkerCommand extends Command {
       return 1;
     }
     $module = $input->getOption('module');
-    $queue_class = $input->getOption('queue-class');
+    $queue_class = $input->getOption('class');
     $plugin_id = $input->getOption('plugin-id');
     $cron_time = $input->getOption('cron-time');
     $label = $input->getOption('label');

--- a/src/Command/Generate/PluginQueueWorkerCommand.php
+++ b/src/Command/Generate/PluginQueueWorkerCommand.php
@@ -10,7 +10,6 @@ use Drupal\Console\Core\Generator\GeneratorInterface;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Symfony\Component\Console\Input\InputOption;
-use Drupal\Console\Extension\Manager;
 use Drupal\Console\Utils\Validator;
 use Drupal\Console\Core\Utils\StringConverter;
 
@@ -30,13 +29,6 @@ class PluginQueueWorkerCommand extends Command {
    * @var \Drupal\Console\Core\Generator\GeneratorInterface
    */
   protected $generator;
-
-  /**
-   * Extension Manager.
-   *
-   * @var \Drupal\Console\Extension\Manager
-   */
-  protected $extensionManager;
 
   /**
    * Validator.
@@ -65,8 +57,6 @@ class PluginQueueWorkerCommand extends Command {
    *
    * @param \Drupal\Console\Core\Generator\GeneratorInterface $queue_generator
    *   Queue Generator.
-   * @param \Drupal\Console\Extension\Manager $extensionManager
-   *   Extension manager.
    * @param \Drupal\Console\Utils\Validator $validator
    *   Validator.
    * @param \Drupal\Console\Core\Utils\StringConverter $stringConverter
@@ -76,13 +66,11 @@ class PluginQueueWorkerCommand extends Command {
    */
   public function __construct(
     GeneratorInterface $queue_generator,
-    Manager $extensionManager,
     Validator $validator,
     StringConverter $stringConverter,
     ChainQueue $chainQueue
   ) {
     $this->generator = $queue_generator;
-    $this->extensionManager = $extensionManager;
     $this->validator = $validator;
     $this->stringConverter = $stringConverter;
     $this->chainQueue = $chainQueue;

--- a/src/Generator/PluginQueueWorkerGenerator.php
+++ b/src/Generator/PluginQueueWorkerGenerator.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Generator\PluginQueueWorkerGenerator.
+ */
+
+namespace Drupal\Console\Generator;
+
+use Drupal\Console\Core\Generator\Generator;
+use Drupal\Console\Extension\Manager;
+
+/**
+ * Class PluginQueueWorkerGenerator.
+ *
+ * @package Drupal\Console\Generator
+ */
+class PluginQueueWorkerGenerator extends Generator {
+
+  /**
+   * Extension Manager.
+   *
+   * @var \Drupal\Console\Extension\Manager
+   */
+  protected $extensionManager;
+
+  /**
+   * PluginQueueWorker constructor.
+   *
+   * @param \Drupal\Console\Extension\Manager $extensionManager
+   *   Extension manager.
+   */
+  public function __construct(
+       Manager $extensionManager
+   ) {
+    $this->extensionManager = $extensionManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generate(array $parameters) {
+    $module = $parameters['module'];
+    $queue_class = $parameters['class_name'];
+
+    $this->renderer->addSkeletonDir(__DIR__ . '/../../console/templates');
+    $this->renderFile(
+      'module/src/Plugin/QueueWorker/queue_worker.php.twig',
+      $this->extensionManager->getPluginPath($module, 'QueueWorker') . '/' . $queue_class . '.php',
+      $parameters
+    );
+  }
+
+}

--- a/src/Generator/PluginQueueWorkerGenerator.php
+++ b/src/Generator/PluginQueueWorkerGenerator.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\Console\Generator\PluginQueueWorkerGenerator.
- */
-
 namespace Drupal\Console\Generator;
 
 use Drupal\Console\Core\Generator\Generator;

--- a/src/Generator/PluginQueueWorkerGenerator.php
+++ b/src/Generator/PluginQueueWorkerGenerator.php
@@ -9,13 +9,14 @@ namespace Drupal\Console\Generator;
 
 use Drupal\Console\Core\Generator\Generator;
 use Drupal\Console\Extension\Manager;
+use Drupal\Console\Core\Generator\GeneratorInterface;
 
 /**
  * Class PluginQueueWorkerGenerator.
  *
  * @package Drupal\Console\Generator
  */
-class PluginQueueWorkerGenerator extends Generator {
+class PluginQueueWorkerGenerator extends Generator implements GeneratorInterface {
 
   /**
    * Extension Manager.

--- a/templates/base/class.php.twig
+++ b/templates/base/class.php.twig
@@ -3,17 +3,16 @@
 {% block namespace_class %}{% endblock %}
 
 {% set _class_path = block('class_path') %}
-
-{% if class_path is not empty %}
+{% if _class_path is not empty %}
 {% block class_docblock %}
 /**
  * @file
  * Contains {% block class_path %}{% endblock %}.
 {% block extra_info %}{% endblock %}
  */
+
 {% endblock %}
 {% endif %}
-
 {% block use_class %}{% endblock %}
 {% block use_class_services %}
 {% if services is defined %}

--- a/templates/base/class.php.twig
+++ b/templates/base/class.php.twig
@@ -2,6 +2,14 @@
 
 {% block namespace_class %}{% endblock %}
 
+{% block class_docblock %}
+/**
+ * @file
+ * Contains {% block class_path %}{% endblock %}.
+{% block extra_info %}{% endblock %}
+ */
+{% endblock %}
+
 {% block use_class %}{% endblock %}
 {% block use_class_services %}
 {% if services is defined %}

--- a/templates/base/class.php.twig
+++ b/templates/base/class.php.twig
@@ -2,17 +2,6 @@
 
 {% block namespace_class %}{% endblock %}
 
-{% set _class_path = block('class_path') %}
-{% if _class_path is not empty %}
-{% block class_docblock %}
-/**
- * @file
- * Contains {% block class_path %}{% endblock %}.
-{% block extra_info %}{% endblock %}
- */
-
-{% endblock %}
-{% endif %}
 {% block use_class %}{% endblock %}
 {% block use_class_services %}
 {% if services is defined %}

--- a/templates/base/class.php.twig
+++ b/templates/base/class.php.twig
@@ -2,6 +2,9 @@
 
 {% block namespace_class %}{% endblock %}
 
+{% set _class_path = block('class_path') %}
+
+{% if class_path is not empty %}
 {% block class_docblock %}
 /**
  * @file
@@ -9,6 +12,7 @@
 {% block extra_info %}{% endblock %}
  */
 {% endblock %}
+{% endif %}
 
 {% block use_class %}{% endblock %}
 {% block use_class_services %}

--- a/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
+++ b/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
@@ -1,9 +1,6 @@
 {% extends "base/class.php.twig" %}
 
-/**
- * @file
- * Contains \Drupal\{{ module }}\Plugin\QueueWorker\{{ queue_file_name }}.
- */
+{% block class_path %}\Drupal\{{ module }}\Plugin\QueueWorker\{{ class_name }}{% endblock %}
 
 {% block namespace_class %}
 namespace Drupal\{{ module }}\Plugin\QueueWorker;

--- a/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
+++ b/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
@@ -1,8 +1,9 @@
 {% extends "base/class.php.twig" %}
 
-{% block file_path %}
-\Drupal\{{ module }}\Plugin\QueueWorker\{{ class_name }}.
-{% endblock %}
+/**
+ * @file
+ * Contains \Drupal\{{ module }}\Plugin\QueueWorker\{{ queue_file_name }}.
+ */
 
 {% block namespace_class %}
 namespace Drupal\{{ module }}\Plugin\QueueWorker;

--- a/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
+++ b/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
@@ -1,7 +1,5 @@
 {% extends "base/class.php.twig" %}
 
-{% block class_path %}\Drupal\{{ module }}\Plugin\QueueWorker\{{ class_name }}{% endblock %}
-
 {% block namespace_class %}
 namespace Drupal\{{ module }}\Plugin\QueueWorker;
 {% endblock %}

--- a/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
+++ b/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
@@ -14,10 +14,10 @@ use Drupal\Core\Queue\QueueWorkerBase;
 
 {% block class_declaration %}
 /**
- * Plugin implementation od the {{ queue_id }} queueworker.
+ * Plugin implementation od the {{ plugin_id }} queueworker.
  *
  * @QueueWorker (
- *   id = "{{ queue_id }}",
+ *   id = "{{ plugin_id }}",
  *   title = @Translation("{{ label }}"),
  *   cron = {"time" = {{ cron_time }}}
  * )

--- a/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
+++ b/templates/module/src/Plugin/QueueWorker/queue_worker.php.twig
@@ -1,0 +1,33 @@
+{% extends "base/class.php.twig" %}
+
+{% block file_path %}
+\Drupal\{{ module }}\Plugin\QueueWorker\{{ class_name }}.
+{% endblock %}
+
+{% block namespace_class %}
+namespace Drupal\{{ module }}\Plugin\QueueWorker;
+{% endblock %}
+
+{% block use_class %}
+use Drupal\Core\Queue\QueueWorkerBase;
+{% endblock %}
+
+{% block class_declaration %}
+/**
+ * Plugin implementation od the {{ queue_id }} queueworker.
+ *
+ * @QueueWorker (
+ *   id = "{{ queue_id }}",
+ *   title = @Translation("{{ label }}"),
+ *   cron = {"time" = {{ cron_time }}}
+ * )
+ */
+class {{ class_name }} extends QueueWorkerBase {% endblock %}
+{% block class_methods %}
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    // Process item operations.
+  }
+{% endblock %}


### PR DESCRIPTION
### Problem/Motivation
Create new command to generate a Queueworker skeleton.
Added doc comment to the base class, optional.

### How to reproduce
I generate a new Queueworker in a existing module using `drupal generate:plugin:queue`.

### Details to include:
Drupal version - 8.6.1
drupal/console 1.8.0 The Drupal CLI. A tool to generate boilerplate code, interact with and debug Drupal.
drupal/console-core 1.8.0 Drupal Console Core
drupal/console-en 1.8.0 Drupal Console English Language
drupal/console-extend-plugin 0.9.2 Drupal Console Extend Plugin
Console Launcher version - 1.8.0

Translation issue: https://github.com/hechoendrupal/drupal-console-en/pull/215
