### PR TITLE
Escape single quotes in .info.ym file generation for generate:module cmd

### DIFF
--- a/src/Generator/ModuleGenerator.php
+++ b/src/Generator/ModuleGenerator.php
@@ -61,6 +61,11 @@ class ModuleGenerator extends Generator
 
         $parameters['type'] = 'module';
 
+        // Escape single quotes in long parameter strings.
+        foreach(['description', 'module'] as $param) {
+            $parameters[$param] = str_replace("'", "''", $parameters[$param]);
+        }
+
         $this->renderFile(
             'module/info.yml.twig',
             $moduleDirectory . '/' . $machineName . '.info.yml',


### PR DESCRIPTION
With unescaped quotes in the module filename - for example, caused by:
```drupal generate:module

 // Welcome to the Drupal module generator

 Enter the new module name:
 > test's this```

You get:
```
drupal generate:module

In InfoParserDynamic.php line 25:

  Unable to parse modules/custom/test_s_this/test_s_this.info.yml Unexpected characters near "s this'" at line 1 (near "name: 'test's this'").
```