### PR TITLE
Fix install errors when using SQLite.

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\Console\Command\Site;
 
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;


### PR DESCRIPTION
While working on making Tome compatible with Drupal Console, I noticed that re-installing with SQLite was quite difficult. If I ran:
```
drupal site:install standard --force --no-interaction
```
Re-installs wouldn't work as there was already a database. I saw that there was special logic for deleting the SQLite file, but when I ran:
```
drupal site:install standard --force --no-interaction --db-type=sqlite --db-file=[...]
```
It only worked every other execution - I think because the SQLite database is re-created every time a query is made.

To me the most clear behavior would be that `drupal site:install standard --force --no-interaction` just works for SQLite, and this PR fixes that by:

1. Setting defaults for options from `settings.php` when using `--no-interaction`. Currently if you already have database connection info defined it will use that instead of the `--db-*` options, but this only happens in interactive mode. Moving the logic block seems like a sane fix.
1. Move to dropping SQLite tables instead of removing the file. This behavior is more clear and has made re-installs stable for me.
