### PR TITLE
FIX #3983: Correct coding standards for EventSubscriber class

### DIFF
--- a/templates/module/src/event-subscriber.php.twig
+++ b/templates/module/src/event-subscriber.php.twig
@@ -20,7 +20,6 @@ use Symfony\Component\EventDispatcher\Event;
 class {{ class }} implements EventSubscriberInterface {% endblock %}
 
 {% block class_construct %}
-
   /**
    * Constructs a new {{ class }} object.
    */
@@ -34,7 +33,7 @@ class {{ class }} implements EventSubscriberInterface {% endblock %}
   /**
    * {@inheritdoc}
    */
-  static function getSubscribedEvents() {
+  public static function getSubscribedEvents() {
 {% for event_name, callback in events %}
     $events['{{ event_name }}'] = ['{{ callback }}'];
 {% endfor %}
@@ -44,10 +43,10 @@ class {{ class }} implements EventSubscriberInterface {% endblock %}
 
 {% for event_name, callback in events %}
   /**
-   * This method is called whenever the {{ event_name }} event is
-   * dispatched.
+   * This method is called whenever the {{ event_name }} event is dispatched.
    *
-   * @param GetResponseEvent $event
+   * @param \Symfony\Component\EventDispatcher\Event $event
+   *   The dispatched event.
    */
   public function {{ callback }}(Event $event) {
     \Drupal::messenger()->addMessage('Event {{ event_name }} thrown by Subscriber in module {{ module }}.', 'status', TRUE);


### PR DESCRIPTION
This PR corrects the coding standards of the EventSubscriber template file.
