### PR TITLE
[update:execute] run trailing post updates if there is no updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
-        "drupal/console-core": "dev-master",
+        "drupal/console-core": "1.8.0",
         "drupal/console-extend-plugin": "~0",
         "guzzlehttp/guzzle": "~6.1",
         "psy/psysh": "0.6.* || ~0.8",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
-        "drupal/console-core": "1.8.0",
+        "drupal/console-core": "dev-master",
         "drupal/console-extend-plugin": "~0",
         "guzzlehttp/guzzle": "~6.1",
         "psy/psysh": "0.6.* || ~0.8",

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -185,7 +185,7 @@ class ExecuteCommand extends Command
                     $currentMaintenanceMode = true;
                 }
                 
-                $this->runPostUpdates();
+                $this->runPostUpdates($postUpdates);
             }
             
             $this->chainQueue->addCommand('update:entities');


### PR DESCRIPTION
We can have trailing postUpdates to run or entities update without having any module update.
This pr try to fix that