### PR TITLE
Update composer.json since drupal-console is not compatible with drupal-console-core 1.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
-        "drupal/console-core": "1.8.0",
+        "drupal/console-core": "dev-master",
         "drupal/console-extend-plugin": "~0",
         "psy/psysh": "0.6.* || ~0.8",
         "symfony/css-selector": "~2.8|~3.0",


### PR DESCRIPTION
`composer.json` lists `drupal/console-core` as a dependency pinned to version 1.8.0. However, this version is missing `\Drupal\Console\Core\Command\Command::enableMaintenance`. This method is present in the `dev-master` version of `drupal/console-core`, so the composer.json in `drupal/console` is updated accordingly in order for `drupal` to run.