### PR TITLE
[generate:plugin:block] Use | to separate inputs

### DIFF
--- a/src/Command/Shared/ArrayInputTrait.php
+++ b/src/Command/Shared/ArrayInputTrait.php
@@ -26,7 +26,7 @@ trait ArrayInputTrait
     {
         $inputs = [];
         foreach ($inlineInputs as $inlineInput) {
-            $explodeInput = explode(',', $inlineInput);
+            $explodeInput = explode('|', $inlineInput);
             $parameters = [];
             foreach ($explodeInput as $inlineParameter) {
                 $inlineParameter = trim($inlineParameter);


### PR DESCRIPTION
This PR should fix https://github.com/hechoendrupal/drupal-console/issues/3975