### PR TITLE
[console] Added the ContainerAwareCommand extension

### DIFF
--- a/src/Command/Generate/AjaxCommand.php
+++ b/src/Command/Generate/AjaxCommand.php
@@ -10,7 +10,6 @@ namespace Drupal\Console\Command\Generate;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Generator\AjaxCommandGenerator;
@@ -27,7 +26,6 @@ use Drupal\Console\Utils\Validator;
 class AjaxCommand extends Command
 {
     use ModuleTrait;
-    use ServicesTrait;
     use ConfirmationTrait;
 
     /**

--- a/src/Command/Generate/AuthenticationProviderCommand.php
+++ b/src/Command/Generate/AuthenticationProviderCommand.php
@@ -11,7 +11,6 @@ use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Generator\AuthenticationProviderGenerator;
@@ -21,7 +20,6 @@ use Drupal\Console\Extension\Manager;
 
 class AuthenticationProviderCommand extends Command
 {
-    use ServicesTrait;
     use ModuleTrait;
     use ConfirmationTrait;
 

--- a/src/Command/Generate/CacheContextCommand.php
+++ b/src/Command/Generate/CacheContextCommand.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Command\Generate;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Generator\CacheContextGenerator;
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CacheContextCommand extends Command
+class CacheContextCommand extends ContainerAwareCommand
 {
     use ModuleTrait;
     use ConfirmationTrait;

--- a/src/Command/Generate/CommandCommand.php
+++ b/src/Command/Generate/CommandCommand.php
@@ -11,7 +11,7 @@ use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ExtensionTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Generator\CommandGenerator;
 use Drupal\Console\Extension\Manager;
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CommandCommand extends Command
+class CommandCommand extends ContainerAwareCommand
 {
     use ConfirmationTrait;
     use ServicesTrait;

--- a/src/Command/Generate/ControllerCommand.php
+++ b/src/Command/Generate/ControllerCommand.php
@@ -11,7 +11,7 @@ use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Generator\ControllerGenerator;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Command\Shared\InputTrait;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Core\Utils\StringConverter;
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ControllerCommand extends Command
+class ControllerCommand extends ContainerAwareCommand
 {
     use ModuleTrait;
     use ServicesTrait;

--- a/src/Command/Generate/EntityBundleCommand.php
+++ b/src/Command/Generate/EntityBundleCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Generator\EntityBundleGenerator;
 use Drupal\Console\Extension\Manager;
 use Drupal\Console\Utils\Validator;
@@ -21,7 +20,6 @@ use Drupal\Console\Utils\Validator;
 class EntityBundleCommand extends Command
 {
     use ModuleTrait;
-    use ServicesTrait;
     use ConfirmationTrait;
 
     /**

--- a/src/Command/Generate/EventSubscriberCommand.php
+++ b/src/Command/Generate/EventSubscriberCommand.php
@@ -11,7 +11,7 @@ use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\EventsTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Extension\Manager;
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class EventSubscriberCommand extends Command
+class EventSubscriberCommand extends ContainerAwareCommand
 {
     use EventsTrait;
     use ServicesTrait;

--- a/src/Command/Generate/FormAlterCommand.php
+++ b/src/Command/Generate/FormAlterCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Generator\FormAlterGenerator;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\FormTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
@@ -32,7 +31,6 @@ class FormAlterCommand extends Command
     use ArrayInputTrait;
     use FormTrait;
     use ModuleTrait;
-    use ServicesTrait;
 
     /**
      * @var Manager

--- a/src/Command/Generate/FormCommand.php
+++ b/src/Command/Generate/FormCommand.php
@@ -12,7 +12,7 @@ use Drupal\Console\Command\Shared\FormTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\MenuTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Generator\FormGenerator;
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class FormCommand extends Command
+abstract class FormCommand extends ContainerAwareCommand
 {
     use ArrayInputTrait;
     use FormTrait;

--- a/src/Command/Generate/PluginBlockCommand.php
+++ b/src/Command/Generate/PluginBlockCommand.php
@@ -12,7 +12,7 @@ use Drupal\Console\Command\Shared\FormTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Generator\PluginBlockGenerator;
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginBlockCommand extends Command
+class PluginBlockCommand extends ContainerAwareCommand
 {
     use ArrayInputTrait;
     use ServicesTrait;

--- a/src/Command/Generate/PluginMailCommand.php
+++ b/src/Command/Generate/PluginMailCommand.php
@@ -11,7 +11,7 @@ use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Generator\PluginMailGenerator;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Extension\Manager;
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @package Drupal\Console\Command\Generate
  */
-class PluginMailCommand extends Command
+class PluginMailCommand extends ContainerAwareCommand
 {
     use ServicesTrait;
     use ModuleTrait;

--- a/src/Command/Generate/PluginRulesActionCommand.php
+++ b/src/Command/Generate/PluginRulesActionCommand.php
@@ -10,7 +10,6 @@ namespace Drupal\Console\Command\Generate;
 use Drupal\Console\Command\Shared\ArrayInputTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Core\Utils\ChainQueue;
@@ -32,7 +31,6 @@ class PluginRulesActionCommand extends Command
     use ArrayInputTrait;
     use ConfirmationTrait;
     use ModuleTrait;
-    use ServicesTrait;
 
     /**
      * @var Manager

--- a/src/Command/Generate/PluginRulesConditionCommand.php
+++ b/src/Command/Generate/PluginRulesConditionCommand.php
@@ -10,7 +10,6 @@ namespace Drupal\Console\Command\Generate;
 use Drupal\Console\Command\Shared\ArrayInputTrait;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Core\Utils\ChainQueue;
@@ -32,7 +31,6 @@ class PluginRulesConditionCommand extends Command
     use ArrayInputTrait;
     use ConfirmationTrait;
     use ModuleTrait;
-    use ServicesTrait;
 
     /**
      * @var Manager

--- a/src/Command/Generate/PluginRulesDataprocessorCommand.php
+++ b/src/Command/Generate/PluginRulesDataprocessorCommand.php
@@ -9,7 +9,6 @@ namespace Drupal\Console\Command\Generate;
 
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Core\Utils\ChainQueue;
@@ -30,7 +29,6 @@ class PluginRulesDataprocessorCommand extends Command
 
     use ConfirmationTrait;
     use ModuleTrait;
-    use ServicesTrait;
 
     /**
      * @var Manager

--- a/src/Command/Generate/PluginTypeAnnotationCommand.php
+++ b/src/Command/Generate/PluginTypeAnnotationCommand.php
@@ -12,7 +12,6 @@ use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Extension\Manager;
@@ -25,7 +24,6 @@ use Drupal\Console\Core\Utils\StringConverter;
  */
 class PluginTypeAnnotationCommand extends Command
 {
-    use ServicesTrait;
     use ModuleTrait;
 
     /**

--- a/src/Command/Generate/PluginTypeYamlCommand.php
+++ b/src/Command/Generate/PluginTypeYamlCommand.php
@@ -12,7 +12,6 @@ use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\Console\Command\Shared\ServicesTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Extension\Manager;
@@ -25,7 +24,6 @@ use Drupal\Console\Core\Utils\StringConverter;
  */
 class PluginTypeYamlCommand extends Command
 {
-    use ServicesTrait;
     use ModuleTrait;
 
     /**

--- a/src/Command/Generate/TwigExtensionCommand.php
+++ b/src/Command/Generate/TwigExtensionCommand.php
@@ -9,7 +9,7 @@ namespace Drupal\Console\Command\Generate;
 use Drupal\Console\Command\Shared\ConfirmationTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Command\Shared\ServicesTrait;
-use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Core\Utils\ChainQueue;
 use Drupal\Console\Core\Utils\StringConverter;
 use Drupal\Console\Extension\Manager;
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @package Drupal\Console\Command\Generate
  */
-class TwigExtensionCommand extends Command
+class TwigExtensionCommand extends ContainerAwareCommand
 {
     use ModuleTrait;
     use ServicesTrait;


### PR DESCRIPTION
This PR should fix https://github.com/hechoendrupal/drupal-console/issues/4033

Commands updated:
```
generate:twig:extension
generate:cache:context
generate:command
generate:controller
generate:event:subscriber
generate:form
generate:plugin:block
generate:plugin:mail
```