### PR TITLE
[database] Run database commands without Drupal bootstrap

### DIFF
--- a/config/services/database.yml
+++ b/config/services/database.yml
@@ -1,19 +1,6 @@
 services:
-  console.database_add:
-    class: Drupal\Console\Command\Database\AddCommand
-    arguments: ['@console.database_settings_generator']
-    tags:
-      - { name: drupal.command }
   console.database_client:
     class: Drupal\Console\Command\Database\ClientCommand
-    tags:
-      - { name: drupal.command }
-  console.database_query:
-    class: Drupal\Console\Command\Database\QueryCommand
-    tags:
-      - { name: drupal.command }
-  console.database_connect:
-    class: Drupal\Console\Command\Database\ConnectCommand
     tags:
       - { name: drupal.command }
   console.database_drop:

--- a/config/services/generator.yml
+++ b/config/services/generator.yml
@@ -201,11 +201,6 @@ services:
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }
-  console.database_settings_generator:
-    class: Drupal\Console\Generator\DatabaseSettingsGenerator
-    arguments: ['@kernel']
-    tags:
-      - { name: drupal.generator }
   console.entitycontent_generator:
     class: Drupal\Console\Generator\EntityContentGenerator
     arguments: ['@console.extension_manager', '@console.site', '@console.renderer']

--- a/src/Generator/DatabaseSettingsGenerator.php
+++ b/src/Generator/DatabaseSettingsGenerator.php
@@ -8,32 +8,21 @@
 namespace Drupal\Console\Generator;
 
 use Drupal\Console\Core\Generator\Generator;
-use Drupal\Core\DrupalKernelInterface;
 
 class DatabaseSettingsGenerator extends Generator
 {
     /**
-     * @var DrupalKernelInterface
-     */
-    protected $kernel;
-
-    /**
      * DatabaseSettingsGenerator constructor.
-     *
-     * @param DrupalKernelInterface $kernel
      */
-    public function __construct(
-        DrupalKernelInterface $kernel
-    ) {
-        $this->kernel = $kernel;
-    }
+    public function __construct() {}
 
     /**
      * {@inheritdoc}
      */
     public function generate(array $parameters)
     {
-        $settingsFile = $this->kernel->getSitePath() . '/settings.php';
+        $uri = parse_url($parameters['uri'], PHP_URL_HOST);
+        $settingsFile = 'sites/'.$uri.'/settings.php';
         if (!is_writable($settingsFile)) {
             return false;
         }

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -11,6 +11,19 @@ services:
     arguments: ['@app.root', '@console.configuration_manager']
     tags:
       - { name: drupal.command }
+  console.database_add:
+    class: Drupal\Console\Command\Database\AddCommand
+    arguments: ['@console.database_settings_generator']
+    tags:
+      - { name: drupal.command }
+  console.database_query:
+    class: Drupal\Console\Command\Database\QueryCommand
+    tags:
+      - { name: drupal.command }
+  console.database_connect:
+    class: Drupal\Console\Command\Database\ConnectCommand
+    tags:
+      - { name: drupal.command }
   console.database_restore:
     class: Drupal\Console\Command\Database\RestoreCommand
     arguments: ['@app.root']
@@ -53,6 +66,10 @@ services:
       - { name: drupal.generator }
   console.docker_init_generator:
     class: Drupal\Console\Generator\DockerInitGenerator
+    tags:
+      - { name: drupal.generator }
+  console.database_settings_generator:
+    class: Drupal\Console\Generator\DatabaseSettingsGenerator
     tags:
       - { name: drupal.generator }
   # Drupal services


### PR DESCRIPTION
This PR should fix https://github.com/hechoendrupal/drupal-console/issues/3097 and took the solution of running database commands and using them without drupal bootstap

Exposed commands:
```
database:add
database:connect
database:query
```