### PR TITLE
[multisite:new] Validated uri name

### DIFF
--- a/src/Command/Multisite/NewCommand.php
+++ b/src/Command/Multisite/NewCommand.php
@@ -8,6 +8,7 @@
 namespace Drupal\Console\Command\Multisite;
 
 use Drupal\Console\Core\Command\Command;
+use Drupal\Console\Utils\Validator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,13 +27,20 @@ class NewCommand extends Command
     protected $appRoot;
 
     /**
+     * @var Validator
+     */
+    protected $validator;
+
+    /**
      * DebugCommand constructor.
      *
      * @param $appRoot
+     * @param Validator $validator
      */
-    public function __construct($appRoot)
+    public function __construct($appRoot, Validator $validator)
     {
         $this->appRoot = $appRoot;
+        $this->validator = $validator;
         parent::__construct();
     }
 
@@ -80,6 +88,7 @@ class NewCommand extends Command
     {
         $this->fs = new Filesystem();
         $this->directory = $input->getArgument('directory');
+        $uri = $this->validator->validateUriName($input->getArgument('uri'));
 
         if (!$this->directory) {
             $this->getIo()->error($this->trans('commands.multisite.new.errors.subdir-empty'));
@@ -117,7 +126,6 @@ class NewCommand extends Command
             return 1;
         }
 
-        $uri = $input->getArgument('uri');
         try {
             $this->addToSitesFile($uri);
         } catch (\Exception $e) {

--- a/src/Utils/Validator.php
+++ b/src/Utils/Validator.php
@@ -17,6 +17,7 @@ class Validator
     const REGEX_CONTROLLER_CLASS_NAME = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+Controller$/';
     const REGEX_MACHINE_NAME = '/^[a-z0-9_]+$/';
     const REGEX_DEPENDENCY_NAME = '/^[a-z0-9_:]+$/';
+    const REGEX_URI_NAME = '/^[a-z0-9_.]+$/';
     // This REGEX remove spaces between words
     const REGEX_REMOVE_SPACES = '/[\\s+]/';
     // Max length to 32
@@ -61,6 +62,20 @@ class Validator
                 sprintf(
                     'Class name "%s" is invalid, it must starts with a letter or underscore, followed by any number of letters, numbers, or underscores.',
                     $class_name
+                )
+            );
+        }
+    }
+
+    public function validateUriName($uri_name)
+    {
+        if (preg_match(self::REGEX_URI_NAME, $uri_name)) {
+            return $uri_name;
+        } else {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Uri name "%s" is invalid, it must starts with a letter, followed by any number of letters, numbers, or underscores.',
+                    $uri_name
                 )
             );
         }

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -36,7 +36,7 @@ services:
       - { name: drupal.command }
   console.multisite_new:
     class: Drupal\Console\Command\Multisite\NewCommand
-    arguments: ['@app.root']
+    arguments: ['@app.root', '@console.validator']
     tags:
       - { name: drupal.command }
   console.multisite_update:


### PR DESCRIPTION
This PR validates the uri name to be able to implement this PR https://github.com/hechoendrupal/drupal-console/pull/3871

Now we can run `drupal multisite:new example example.com` this creates a folder called `example` but the multisite is called `example.com`

The reference in sites.php
```
$sites['example.com'] = 'example';

```
