### PR TITLE
[site:install] Improve support of --db-url

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -226,8 +226,7 @@ class InstallCommand extends ContainerAwareCommand
         $is_database_info_set = false;
 
         // Use default database setting if is available
-        //$database = Database::getConnectionInfo();
-        $database = null;
+        $database = Database::getConnectionInfo();
         if (!empty($database['default'])) {
             $this->getIo()->info(
                 sprintf(

--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -253,7 +253,7 @@ class InstallCommand extends ContainerAwareCommand
                     )
                 );
                 $is_database_info_set = true;
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 $this->getIo()->warning('Invalid --db-url argument: ' . $e->getMessage());
             }
         }

--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -226,7 +226,8 @@ class InstallCommand extends ContainerAwareCommand
         $is_database_info_set = false;
 
         // Use default database setting if is available
-        $database = Database::getConnectionInfo();
+        //$database = Database::getConnectionInfo();
+        $database = null;
         if (!empty($database['default'])) {
             $this->getIo()->info(
                 sprintf(


### PR DESCRIPTION
Looking at the newly introduced --db-url argument for site:install, I believe there's room for some improvements.

If --db-url is specified **and valid**, there is no purpose to go through the other options. We can just install based on that.

Here's my suggested changes  - **not for merging yet** but rather for sharing with the community - I am new to Drupal console contribution so please bear with me.

My goal: allow `site:install` to run on ANY database driver (also contributed), as long as it complies to the Drupal API for `Database::convertDbUrlToConnectionInfo` and `Database::getConnectionInfoAsUrl`.