### PR TITLE
[update:execute] Support batch updates and post update functions

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -348,13 +348,24 @@ class ExecuteCommand extends Command
 
     private function executeUpdate($function, &$context)
     {
-        if (!$context || !array_key_exists('sandbox', $context)) {
-            $context['sandbox'] = [];
-        }
+        $context['sandbox'] = [];
+        do {
+            if (function_exists($function)) {
+                $return = $function($context['sandbox']);
 
-        if (function_exists($function)) {
-            $function($context['sandbox']);
-        }
+                if (is_string($return)) {
+                    $this->getIo()->info(
+                        "  ".$return
+                    );
+                }
+
+                if (isset($context['sandbox']['#finished']) && ($context['sandbox']['#finished'] < 1)) {
+                    $this->getIo()->info(
+                        '  Processed '.number_format($context['sandbox']['#finished'] * 100, 2).'%'
+                    );
+                }
+            }
+        } while (isset($context['sandbox']['#finished']) && ($context['sandbox']['#finished'] < 1));
 
         return true;
     }


### PR DESCRIPTION
See Issue #3929

### Problem/Motivation
drupal updb does not support batch updates. This has made updating from 8.6.x - 8.7.0 impossible as several of the post_update functions require batch processing.

Details of how to reproduce can be found on issue #3929 

### Solution
Update ExecuteCommand::executeUpdate() to loop over the update function until it is completed. Provide helpful feedback to the user throughout this process.

I've added a `do { } while() ` loop into executeUpdate to ensure that the function get's run the correct number of time.

A default message of 'Processed x%' is printed as information and indented to make clear that it relates to the function above.

![batchupdatefunction](https://user-images.githubusercontent.com/879407/58191799-403b5380-7cb7-11e9-92d5-719a20775e15.png)
