### PR TITLE
[templates] Add code standard

### DIFF
--- a/src/Generator/FormAlterGenerator.php
+++ b/src/Generator/FormAlterGenerator.php
@@ -35,6 +35,11 @@ class FormAlterGenerator extends Generator
     {
         $module = $parameters['module'];
         $module_path =  $this->extensionManager->getModule($module)->getPath();
+        $moduleFilePath =  $this->extensionManager->getModule($module)->getPath() . '/' . $module . '.module';
+
+        $parameters = array_merge($parameters, [
+            'file_exists' => file_exists($moduleFilePath),
+        ]);
 
         $this->renderFile(
             'module/src/Form/form-alter.php.twig',

--- a/templates/module/help.php.twig
+++ b/templates/module/help.php.twig
@@ -1,8 +1,15 @@
 {% block file_methods %}
 {% if not file_exists %}
 {% include 'module/php_tag.php.twig' %}
+
+/**
+ * @file
+ * Main module help for the {{ machine_name }} module.
+ */
+
 {% endif %}
 use Drupal\Core\Routing\RouteMatchInterface;
+
 /**
  * Implements hook_help().
  */
@@ -18,5 +25,4 @@ function {{machine_name}}_help($route_name, RouteMatchInterface $route_match) {
     default:
   }
 }
-
 {% endblock %}

--- a/templates/module/links.menu.yml.twig
+++ b/templates/module/links.menu.yml.twig
@@ -4,4 +4,3 @@
   description: '{{ menu_link_desc }}'
   parent: {{ menu_parent }}
   weight: 99
-

--- a/templates/module/routing-form.yml.twig
+++ b/templates/module/routing-form.yml.twig
@@ -1,5 +1,4 @@
 {% if class_name is defined %}
-
 {{ module_name }}.{{form_id}}:
   path: '{{ path }}'
   defaults:

--- a/templates/module/src/Form/form-alter.php.twig
+++ b/templates/module/src/Form/form-alter.php.twig
@@ -1,3 +1,11 @@
+{% if not file_exists %}
+{% include 'module/php_tag.php.twig' %}
+
+/**
+ * @file
+ * Contains {{ module }} form alter.
+ */
+{% endif %}
 
 {% block use_class %}
 use Drupal\Core\Form\FormStateInterface;
@@ -15,49 +23,49 @@ function {{ module }}_form_{{ form_id }}_alter(&$form, FormStateInterface $form_
     \Drupal::messenger()->addMessage('{{ module }}_form_{{ form_id }}_alter() executed.');
 {% else %}
 /**
- * Implements hook_form_alter() on behalf of {{ module }}.module.
+ * Implements hook_form_alter().
  */
 function {{ module }}_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-    // Change form id here
-    if ($form_id == 'form_test_alter_form') {
-        \Drupal::messenger()->addMessage('form_test_form_alter() executed.');
+  // Change form id here.
+  if ($form_id == 'form_test_alter_form') {
+    \Drupal::messenger()->addMessage('form_test_form_alter() executed.');
 {% endif %}
 
 {%- if metadata.unset -%}
 {% for field in metadata.unset %}
-        $form['{{ field }}']['#access'] = FALSE;
+    $form['{{ field }}']['#access'] = FALSE;
 {% endfor %}
 {% endif %}
 
 {% if inputs %}
 {% for input in inputs %}
-        $form['{{ input.name }}'] = [
-            '#type' => '{{ input.type }}',
-            '#title' => t('{{ input.label|e }}'),
-    {%- if input.description is defined and input.description is defined -%}
-            '#description' => t('{{ input.description|e }}'),
-    {% endif %}
-    {%- if input.options is defined and input.options|length -%}
-            '#options' => {{ input.options }},
-    {% endif %}
-    {%- if input.maxlength is defined and input.maxlength|length -%}
-            '#maxlength' => {{ input.maxlength }},
-    {% endif %}
-    {%- if input.size is defined and input.size|length -%}
-            '#size' => {{ input.size }},
-    {% endif %}
-    {%- if input.default_value is defined and input.default_value|length -%}
-            '#default_value' => '{{ input.default_value }}',
-    {% endif %}
-    {%- if input.weight is defined and input.weight|length -%}
-            '#weight' => '{{ input.weight }}',
-    {% endif %}
-        ];
+    $form['{{ input.name }}'] = [
+      '#type' => '{{ input.type }}',
+      '#title' => t('{{ input.label|e }}'),
+{% if input.description is defined and input.description is not empty %}
+      '#description' => t('{{ input.description|e }}'),
+{% endif %}
+{% if input.options is defined and input.options|length %}
+      '#options' => {{ input.options }},
+{% endif %}
+{% if input.maxlength is defined and input.maxlength|length %}
+      '#maxlength' => {{ input.maxlength }},
+{% endif %}
+{% if input.size is defined and input.size|length %}
+      '#size' => {{ input.size }},
+{% endif %}
+{% if input.default_value is defined and input.default_value|length %}
+      '#default_value' => '{{ input.default_value }}',
+{% endif %}
+{% if input.weight is defined and input.weight is not empty%}
+      '#weight' => '{{ input.weight }}',
+{% endif %}
+    ];
 
 {% endfor %}
 {% endif %}
 {% if form_id is empty %}
-    }
+  }
 {% endif %}
 }
 {% endblock %}

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -1,7 +1,7 @@
 {% extends "base/class.php.twig" %}
 
 {% block file_path %}
-Drupal\{{module_name}}\Form\{{ class_name }}.
+\Drupal\{{module_name}}\Form\{{ class_name }}.
 {% endblock %}
 
 {% block namespace_class %}
@@ -29,10 +29,10 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
-      {{ servicesAsParameters(services)|join(',\n    ') }}
-    ) {
+    {{ servicesAsParameters(services)|join(',\n    ') }}
+  ) {
     parent::__construct($config_factory);
-    {{ serviceClassInitialization(services) }}
+{{ serviceClassInitialization(services) }}
   }
 
 {% endif %}
@@ -40,10 +40,13 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
 
 {% block class_create %}
 {% if services is not empty %}
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      {{ serviceClassInjection(services) }}
+{{ serviceClassInjection(services) }}
     );
   }
 
@@ -98,13 +101,6 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
     ];
 {% endfor %}
     return parent::buildForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
   }
 
   /**

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -24,7 +24,6 @@ class {{ class_name }} extends FormBase {% endblock %}
 
 {% block class_construct %}
 {% if services is not empty %}
-
   /**
    * Constructs a new {{ class_name }} object.
    */
@@ -47,11 +46,11 @@ class {{ class_name }} extends FormBase {% endblock %}
 {{ serviceClassInjection(services) }}
     );
   }
+
 {% endif %}
 {% endblock %}
 
 {% block class_methods %}
-
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
The following commands were updated with code standard:
```
generate:form
generate:form:alter
generate:form:config
generate:help
generate:jstest
```