### PR TITLE
Remove unused variable

### DIFF
--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -82,8 +82,6 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
     }
 {% endif %}
 
-    $entity = $this->entity;
-
     return $form;
   }
 


### PR DESCRIPTION
- Variable $entity is not used, so PHP CS is throwing a warning about an unused variable.