### PR TITLE
Execute database command without drupal boostap

### DIFF
--- a/config/services/database.yml
+++ b/config/services/database.yml
@@ -1,8 +1,4 @@
 services:
-  console.database_client:
-    class: Drupal\Console\Command\Database\ClientCommand
-    tags:
-      - { name: drupal.command }
   console.database_drop:
     class: Drupal\Console\Command\Database\DropCommand
     tags:

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -11,6 +11,10 @@ services:
     arguments: ['@app.root', '@console.configuration_manager']
     tags:
       - { name: drupal.command }
+  console.database_client:
+    class: Drupal\Console\Command\Database\ClientCommand
+    tags:
+      - { name: drupal.command }
   console.database_add:
     class: Drupal\Console\Command\Database\AddCommand
     arguments: ['@console.database_settings_generator']


### PR DESCRIPTION
This should be partially fixed.
 https://github.com/hechoendrupal/drupal-console/issues/3514