### PR TITLE
[ console] DrupalCommand annotation fails when $extension_type is equal to "profile"

### DIFF
--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -192,9 +192,15 @@ class Manager
             $name = $extension->getName();
 
             $isInstalled = false;
-            if (property_exists($extension, 'status')) {
-                $isInstalled = ($extension->status)?true:false;
+            if ($type == 'profile') {
+              $isInstalled =  \Drupal::installProfile() == $name;
             }
+            else {
+              if (property_exists($extension, 'status')) {
+                $isInstalled = ($extension->status) ? TRUE : FALSE;
+              }
+            }
+
             if (!$showInstalled && $isInstalled) {
                 continue;
             }

--- a/src/Utils/TranslatorManager.php
+++ b/src/Utils/TranslatorManager.php
@@ -51,6 +51,22 @@ class TranslatorManager extends TranslatorManagerBase
     }
 
     /**
+     * @param $profile
+     */
+    private function addResourceTranslationsByProfile($profile)
+    {
+        // No "profile handler" service exists yet, so we have to get
+        // paths the old fashioned way.
+        if (\Drupal::installProfile() != $profile) {
+            return;
+        }
+        $extensionPath = drupal_get_path('profile', $profile);
+        $this->addResourceTranslationsByExtensionPath(
+            $extensionPath
+        );
+    }
+
+    /**
      * @param $module
      */
     private function addResourceTranslationsByModule($module)
@@ -99,6 +115,10 @@ class TranslatorManager extends TranslatorManagerBase
         }
 
         $this->extensions[] = $extension;
+        if ($type == 'profile') {
+            $this->addResourceTranslationsByProfile($extension);
+            return;
+        }
         if ($type == 'module') {
             $this->addResourceTranslationsByModule($extension);
             return;


### PR DESCRIPTION
### Problem/Motivation
Generated commands on an install profile are unable to run due to the DrupalCommand failing whenever $extension_type is set to "profile".

### How to reproduce
Include steps related how to reproduce.
- Drupal version: 8.7.1
- Console version: 1.8.0
- Create a custom installation profile and install it on a site.
- Generate a new Drupal Console command. (drupal gco --extension="my-new-profile" --extension-type="profile" --class="DefaultCommand" --name="DefaultCommandName")
- Run the command.

### Solution
- Change Drupal\Console\Extension\Manager to properly detect the currently installed site profile.
- Implement addResourceTranslationsByProfile() on Drupal\Console\Utils\TranslationManager.