### PR TITLE
[user:create] Ensure $roles is an array when creating users.

### DIFF
--- a/src/Command/User/CreateCommand.php
+++ b/src/Command/User/CreateCommand.php
@@ -108,6 +108,9 @@ class CreateCommand extends Command
         $username = $input->getArgument('username');
         $password = $input->getArgument('password');
         $roles = $input->getOption('roles');
+        if (is_string($roles)) {
+            $roles = explode(',', $roles);
+        }
         $email = $input->getOption('email');
         $status = $input->getOption('status');
 


### PR DESCRIPTION
This prevents an error from being thrown when constructing the success message.  See #4133.