### PR TITLE
Add bundle permissions for content entity

### DIFF
--- a/src/Command/Generate/EntityContentCommand.php
+++ b/src/Command/Generate/EntityContentCommand.php
@@ -109,7 +109,16 @@ class EntityContentCommand extends EntityCommand
             null,
             InputOption::VALUE_NONE,
             $this->trans('commands.generate.entity.content.options.has-owner')
-        )->setAliases(['geco']);
+        );
+
+        $this->addOption(
+            'has-bundle-permissions',
+            null,
+            InputOption::VALUE_NONE,
+            $this->trans('commands.generate.entity.content.options.has-bundle-permissions')
+        );
+
+        $this->setAliases(['geco']);
     }
 
     /**
@@ -156,6 +165,13 @@ class EntityContentCommand extends EntityCommand
             true
         );
         $input->setOption('has-owner', $has_owner);
+
+        // --has-bundle-permissions
+        $has_bundle_permissions = $this->getIo()->confirm(
+            $this->trans('commands.generate.entity.content.questions.has-bundle-permissions'),
+            true
+        );
+        $input->setOption('has-bundle-permissions', $has_bundle_permissions);
     }
 
     /**
@@ -175,6 +191,7 @@ class EntityContentCommand extends EntityCommand
         $revisionable = $input->getOption('revisionable');
         $has_forms = $input->getOption('has-forms');
         $has_owner = $input->getOption('has-owner');
+        $has_bundle_permissions = $input->getOption('has-bundle-permissions');
 
         $generator = $this->generator;
 
@@ -193,6 +210,7 @@ class EntityContentCommand extends EntityCommand
             'revisionable' => $revisionable,
             'has_forms' => $has_forms,
             'has_owner' => $has_owner,
+            'has_bundle_permissions' => $has_bundle_permissions,
         ]);
 
         if ($has_bundles) {

--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -83,6 +83,14 @@ class EntityContentGenerator extends Generator
             FILE_APPEND
         );
 
+        if ($has_bundle_permissions) {
+            $this->renderFile(
+            'module/src/entity-content-bundle-permissions.php.twig',
+            $moduleSourcePath . 'Permissions.php',
+            $parameters
+          );
+        }
+
         $this->renderFile(
             'module/src/accesscontrolhandler-entity-content.php.twig',
             $moduleSourcePath . 'AccessControlHandler.php',

--- a/src/Generator/EntityContentGenerator.php
+++ b/src/Generator/EntityContentGenerator.php
@@ -65,6 +65,7 @@ class EntityContentGenerator extends Generator
         $is_translatable = $parameters['is_translatable'];
         $revisionable = $parameters['revisionable'];
         $has_forms = $parameters['has_forms'];
+        $has_bundle_permissions = $parameters['has_bundle_permissions'];
 
         $moduleInstance = $this->extensionManager->getModule($module);
         $moduleDir = $moduleInstance->getPath();

--- a/templates/module/permissions-entity-content.yml.twig
+++ b/templates/module/permissions-entity-content.yml.twig
@@ -30,3 +30,8 @@ delete all {{ label|lower }} revisions:
   title: 'Delete all revisions'
   description: 'Role requires permission to <em>view {{ label }} revisions</em> and <em>delete rights</em> for {{ label|lower }} entities in question or <em>administer {{ label|lower }} entities</em>.'
 {% endif %}
+
+{% if has_bundle_permissions %}
+permission_callbacks:
+  - \Drupal\{{ module }}\{{ entity_class}}Permissions::generatePermissions
+{% endif %}

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -14,7 +14,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 {% endif %}
 use Drupal\Core\Field\BaseFieldDefinition;
 {% if revisionable %}
-use Drupal\Core\Entity\EditorialContentEntityBase
+use Drupal\Core\Entity\EditorialContentEntityBase;
 use Drupal\Core\Entity\RevisionableInterface;
 {% else %}
 use Drupal\Core\Entity\ContentEntityBase;

--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -72,6 +72,9 @@ use Drupal\user\UserInterface;
  *   revision_data_table = "{{ entity_name }}_field_revision",
 {% endif %}
  *   translatable = {{ is_translatable ? 'TRUE' : 'FALSE' }},
+{% if has_bundle_permissions %}
+ *   permission_granularity = "bundle",
+{% endif %}
  *   admin_permission = "administer {{ label|lower }} entities",
  *   entity_keys = {
  *     "id" = "id",

--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -28,17 +28,49 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
     /** @var \Drupal\{{ module }}\Entity\{{ entity_class }}Interface $entity */
+
     switch ($operation) {
+
       case 'view':
+
         if (!$entity->isPublished()) {
+{% if has_bundle_permissions %}
+          $permission = $this->checkOwn($entity, 'view unpublished', $account);
+          if (!empty($permission)) {
+            return AccessResult::allowed();
+          }
+
+{%  endif %}
           return AccessResult::allowedIfHasPermission($account, 'view unpublished {{ label|lower }} entities');
         }
+
+{% if has_bundle_permissions %}
+        $permission = $this->checkOwn($entity, $operation, $account);
+        if (!empty($permission)) {
+          return AccessResult::allowed();
+        }
+{%  endif %}
+
         return AccessResult::allowedIfHasPermission($account, 'view published {{ label|lower }} entities');
 
       case 'update':
+
+{% if has_bundle_permissions %}
+        $permission = $this->checkOwn($entity, $operation, $account);
+        if (!empty($permission)) {
+          return AccessResult::allowed();
+        }
+{%  endif %}
         return AccessResult::allowedIfHasPermission($account, 'edit {{ label|lower }} entities');
 
       case 'delete':
+
+{% if has_bundle_permissions %}
+        $permission = $this->checkOwn($entity, $operation, $account);
+        if (!empty($permission)) {
+          return AccessResult::allowed();
+        }
+{%  endif %}
         return AccessResult::allowedIfHasPermission($account, 'delete {{ label|lower }} entities');
     }
 
@@ -52,4 +84,51 @@ class {{ entity_class }}AccessControlHandler extends EntityAccessControlHandler 
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
     return AccessResult::allowedIfHasPermission($account, 'add {{ label|lower }} entities');
   }
+
+{% if has_bundle_permissions %}
+  /**
+   * Test for given 'own' permission.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param $operation
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *
+   * @return string|null
+   *   The permission string indicating it's allowed.
+   */
+  protected function checkOwn(EntityInterface $entity, $operation, AccountInterface $account) {
+    $status = $entity->isPublished();
+    $uid = $entity->getOwnerId();
+
+    $is_own = $account->isAuthenticated() && $account->id() == $uid;
+    if (!$is_own) {
+      return;
+    }
+
+    $bundle = $entity->bundle();
+
+    $ops = [
+      'create' => '%bundle add own %bundle entities',
+      'view unpublished' => '%bundle view own unpublished %bundle entities',
+      'view' => '%bundle view own entities',
+      'update' => '%bundle edit own entities',
+      'delete' => '%bundle delete own entities',
+    ];
+    $permission = strtr($ops[$operation], ['%bundle' => $bundle]);
+
+    if ($operation === 'view unpublished') {
+      if (!$status && $account->hasPermission($permission)) {
+        return $permission;
+      }
+      else {
+        return NULL;
+      }
+    }
+    if ($account->hasPermission($permission)) {
+      return $permission;
+    }
+
+    return NULL;
+  }
+{% endif %}
 {% endblock %}

--- a/templates/module/src/entity-content-bundle-permissions.php.twig
+++ b/templates/module/src/entity-content-bundle-permissions.php.twig
@@ -58,33 +58,35 @@ class {{ entity_class }}Permissions{% endblock %}
     $type_params = ['%type_name' => $type->label()];
 
     return [
-      "create $type_id content" => [
-        'title' => $this->t('%type_name: Create new content', $type_params),
+      "$type_id create entities" => [
+        'title' => $this->t('Create new %type_name entities', $type_params),
       ],
-      "edit own $type_id content" => [
-        'title' => $this->t('%type_name: Edit own content', $type_params),
+      "$type_id edit own entities" => [
+        'title' => $this->t('Edit own %type_name entities', $type_params),
       ],
-      "edit any $type_id content" => [
-        'title' => $this->t('%type_name: Edit any content', $type_params),
+      "$type_id edit any entities" => [
+        'title' => $this->t('Edit any %type_name entities', $type_params),
       ],
-      "delete own $type_id content" => [
-        'title' => $this->t('%type_name: Delete own content', $type_params),
+      "$type_id delete own entities" => [
+        'title' => $this->t('Delete own %type_name entities', $type_params),
       ],
-        "delete any $type_id content" => [
-        'title' => $this->t('%type_name: Delete any content', $type_params),
+      "$type_id delete any entities" => [
+        'title' => $this->t('Delete any %type_name entities', $type_params),
       ],
-      "view $type_id revisions" => [
-        'title' => $this->t('%type_name: View revisions', $type_params),
-        'description' => t('To view a revision, you also need permission to view the content item.'),
+{% if revisionable %}
+      "$type_id view revisions" => [
+        'title' => $this->t('View %type_name revisions', $type_params),
+        'description' => t('To view a revision, you also need permission to view the entity item.'),
       ],
-      "revert $type_id revisions" => [
-        'title' => $this->t('%type_name: Revert revisions', $type_params),
-        'description' => t('To revert a revision, you also need permission to edit the content item.'),
+      "$type_id revert revisions" => [
+        'title' => $this->t('Revert %type_name revisions', $type_params),
+        'description' => t('To revert a revision, you also need permission to edit the entity item.'),
       ],
-      "delete $type_id revisions" => [
-        'title' => $this->t('%type_name: Delete revisions', $type_params),
-        'description' => $this->t('To delete a revision, you also need permission to delete the content item.'),
+      "$type_id delete revisions" => [
+        'title' => $this->t('Delete %type_name revisions', $type_params),
+        'description' => $this->t('To delete a revision, you also need permission to delete the entity item.'),
       ],
+{% endif %}
     ];
   }
 {% endblock %}

--- a/templates/module/src/entity-content-bundle-permissions.php.twig
+++ b/templates/module/src/entity-content-bundle-permissions.php.twig
@@ -1,0 +1,90 @@
+
+{% extends "base/class.php.twig" %}
+
+{% block file_path %}
+  \Drupal\{{ module }}\Entity\{{ entity_class }}.
+{% endblock %}
+
+{% block namespace_class %}
+namespace Drupal\{{ module }};
+{% endblock %}
+
+{% block use_class %}
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\{{ module }}\Entity\{{ entity_class }}Type;
+
+{% endblock %}
+
+{% block class_declaration %}
+/**
+ * Provides dynamic permissions for {{ label }} of different types.
+ *
+ * @ingroup {{ module }}
+ *
+ */
+class {{ entity_class }}Permissions{% endblock %}
+
+{% block class_methods %}
+  use StringTranslationTrait;
+
+  /**
+   * Returns an array of node type permissions.
+   *
+   * @return array
+   *   The {{ entity_class }} by bundle permissions.
+   *   @see \Drupal\user\PermissionHandlerInterface::getPermissions()
+   */
+  public function generatePermissions() {
+    $perms = [];
+
+    foreach ({{ entity_class }}Type::loadMultiple() as $type) {
+      $perms += $this->buildPermissions($type);
+    }
+
+    return $perms;
+  }
+
+  /**
+   * Returns a list of node permissions for a given node type.
+   *
+   * @param \Drupal\{{ module }}\Entity\{{ entity_class }}Type $type
+   *   The {{ entity_class }} type.
+   *
+   * @return array
+   *   An associative array of permission names and descriptions.
+   */
+  protected function buildPermissions({{ entity_class}}Type $type) {
+    $type_id = $type->id();
+    $type_params = ['%type_name' => $type->label()];
+
+    return [
+      "create $type_id content" => [
+        'title' => $this->t('%type_name: Create new content', $type_params),
+      ],
+      "edit own $type_id content" => [
+        'title' => $this->t('%type_name: Edit own content', $type_params),
+      ],
+      "edit any $type_id content" => [
+        'title' => $this->t('%type_name: Edit any content', $type_params),
+      ],
+      "delete own $type_id content" => [
+        'title' => $this->t('%type_name: Delete own content', $type_params),
+      ],
+        "delete any $type_id content" => [
+        'title' => $this->t('%type_name: Delete any content', $type_params),
+      ],
+      "view $type_id revisions" => [
+        'title' => $this->t('%type_name: View revisions', $type_params),
+        'description' => t('To view a revision, you also need permission to view the content item.'),
+      ],
+      "revert $type_id revisions" => [
+        'title' => $this->t('%type_name: Revert revisions', $type_params),
+        'description' => t('To revert a revision, you also need permission to edit the content item.'),
+      ],
+      "delete $type_id revisions" => [
+        'title' => $this->t('%type_name: Delete revisions', $type_params),
+        'description' => $this->t('To delete a revision, you also need permission to delete the content item.'),
+      ],
+    ];
+  }
+{% endblock %}


### PR DESCRIPTION
PR for https://github.com/hechoendrupal/drupal-console/issues/3498

### Description

This patch generates bundle specific permissions related to CRUD with implementation and sets up permissions for revisioning but does not implement the checks as I did not see revisions in the UI.

### Tasks

(still little sketchy)

- [x] Add switch --permission_granularity [bundle|entity_type] to command chain for EntityContentGenerator
- [x] Adjust templates/module/src/accesscontrolhandler-entity-content.php.twig to generate fine grained permissions
- [x] Add permission_granularity to templates/module/src/Entity/entity-content.php.twig
- [x] vendor/drupal/console/templates/module/src/Controller/entity-controller.php.twig
- [x] Something similar to \Drupal\node\NodePermissions for when creating a new entityType it's permissions are made available too.
- [x] this is called from core/modules/node/node.permissions.yml:27 permission_callbacks
- [x] PR https://github.com/hechoendrupal/drupal-console-en/pull/250 Add translations to `console-en`

### Testing

This depends on PR https://github.com/hechoendrupal/drupal-console/pull/4139 for revisionable.

#### Remove generated module

```
# delete module
rm -r modules/custom/test_changes

# Generate module
vendor/bin/drupal \
  --no-interaction \
  generate:module  \
  --module="Test changes"  \
  --machine-name="test_changes"  \
  --module-path="modules/custom"  \
  --description="Test changes done on drupal/console"  \
  --core="8.x"  \
  --package="Other"  \
  --dependencies="" \
  --module-file  \
  --test

# Generate Entity
vendor/bin/drupal \
  --no-interaction \
  generate:entity:content  \
  --module="test_changes"  \
  --entity-class="TestChanges"  \
  --entity-name="test_changes"  \
  --base-path="/admin/content"  \
  --label="Test Changes"  \
  --is-translatable \
  --revisionable \
  --has-forms \
  --has-bundles \
  --has-owner \
  --has-bundle-permissions

# Code sane?
drush cache-rebuild

# Enable
drush pm:enable test_changes
```

#### Visit affected pages

- [x] OK? http://drupal.d8/admin/people/permissions
- [x] OK? http://drupal.d8/admin/structure/test_changes_type
- [x] OK? http://drupal.d8/admin/content/test_changes

```
# Uninstall
drush pm:uninstall test_changes
```