### PR TITLE
Add --default option to database:add

### DIFF
--- a/src/Command/Database/AddCommand.php
+++ b/src/Command/Database/AddCommand.php
@@ -83,6 +83,12 @@ class AddCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 $this->trans('commands.database.add.options.driver')
             )
+            ->addOption(
+                'default',
+                null,
+                InputOption::VALUE_NONE,
+                $this->trans('commands.database.query.options.default')
+            )
             ->setHelp($this->trans('commands.database.add.help'))
             ->setAliases(['dba']);
     }

--- a/src/Generator/DatabaseSettingsGenerator.php
+++ b/src/Generator/DatabaseSettingsGenerator.php
@@ -26,8 +26,12 @@ class DatabaseSettingsGenerator extends Generator
         if (!is_writable($settingsFile)) {
             return false;
         }
+        $template = 'database/add.php.twig';
+        if ($parameters['default']) {
+            $template = 'database/add-default.php.twig';
+        }
         return $this->renderFile(
-            'database/add.php.twig',
+            $template,
             $settingsFile,
             $parameters,
             FILE_APPEND

--- a/templates/database/add-default.php.twig
+++ b/templates/database/add-default.php.twig
@@ -1,0 +1,10 @@
+
+$databases['default']['default'] = [
+  'database' => '{{ database }}',
+  'username' => '{{ username }}',
+  'password' => '{{ password }}',
+  'host' => '{{ host }}',
+  'port' => '{{ port }}',
+  'driver' => '{{ driver }}',
+  'prefix' => '{{ prefix }}',
+];


### PR DESCRIPTION
This option allows to set the database as the default one instead of
adding a new database in addition to the default one.

See: https://github.com/hechoendrupal/drupal-console/issues/4142