### PR TITLE
Fix path config:export on root Drupal

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -98,6 +98,7 @@ class ExportCommand extends Command
         $tar = $input->getOption('tar');
         $removeUuid = $input->getOption('remove-uuid');
         $removeHash = $input->getOption('remove-config-hash');
+        $drupal_root = $this->drupalFinder->getComposerRoot();
 
         if (!$directory) {
             $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
@@ -105,7 +106,7 @@ class ExportCommand extends Command
 
         $fileSystem = new Filesystem();
         try {
-            $fileSystem->mkdir($directory);
+            $fileSystem->mkdir($drupal_root."/".$directory);
         } catch (IOExceptionInterface $e) {
             $this->getIo()->error(
                 sprintf(


### PR DESCRIPTION
Fix path generating config:export. 

Generating the directory in root Drupal when is applied the next command.

```drupal config:export``` path relative
or 
```drupal config:export --directory=config2.test```
or 
```drupal config:export --directory="mod/config2.test"```

![testin2](https://user-images.githubusercontent.com/6983125/65053988-77063b00-d932-11e9-84ce-a17d44bc220f.png)
