### PR TITLE
Fix path directory and to create config files

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -94,7 +94,8 @@ class ExportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $directory = $input->getOption('directory');
+        $drupal_root = $this->drupalFinder->getComposerRoot();
+        $directory = $drupal_root.'/'.$input->getOption('directory');
         $tar = $input->getOption('tar');
         $removeUuid = $input->getOption('remove-uuid');
         $removeHash = $input->getOption('remove-config-hash');


### PR DESCRIPTION
Fix path directory generating drupal ```config:export --directory=config.test``` and to create config files as well in root dir.

Thanks.