### PR TITLE
[generate:cache:context] Typo in CacheContextGenerator

### DIFF
--- a/src/Generator/CacheContextGenerator.php
+++ b/src/Generator/CacheContextGenerator.php
@@ -34,7 +34,7 @@ class CacheContextGenerator extends Generator
     public function generate(array $parameters)
     {
         $module = $parameters['module'];
-        $cache_context = $parameters['ache_context'];
+        $cache_context = $parameters['cache_context'];
         $class = $parameters['class'];
 
         $moduleInstance = $this->extensionManager->getModule($module);


### PR DESCRIPTION
Hi,

A typo in CacheContextGenerator prevents the generation of files.

