### PR TITLE
[generate:block:type] New command

### DIFF
--- a/config/services/generate.yml
+++ b/config/services/generate.yml
@@ -197,6 +197,11 @@ services:
     arguments: ['@config.factory', '@console.chain_queue', '@console.pluginblock_generator', '@entity_type.manager', '@console.extension_manager', '@console.validator', '@console.string_converter', '@plugin.manager.element_info']
     tags:
        - { name: drupal.command }
+  console.generate_blocktype:
+    class: Drupal\Console\Command\Generate\BlockTypeCommand
+    arguments: ['@config.factory', '@console.chain_queue', '@console.blocktype_generator', '@entity_type.manager', '@console.extension_manager', '@console.validator', '@console.string_converter', '@plugin.manager.element_info']
+    tags:
+       - { name: drupal.command }
   console.generate_command:
     class: Drupal\Console\Command\Generate\CommandCommand
     arguments: ['@console.command_generator', '@console.extension_manager', '@console.validator', '@console.string_converter', '@console.site']

--- a/config/services/generator.yml
+++ b/config/services/generator.yml
@@ -191,6 +191,11 @@ services:
     arguments: ['@console.extension_manager']
     tags:
       - { name: drupal.generator }
+  console.blocktype_generator:
+    class: Drupal\Console\Generator\BlockTypeGenerator
+    arguments: ['@console.extension_manager']
+    tags:
+      - { name: drupal.generator }
   console.command_generator:
     class: Drupal\Console\Generator\CommandGenerator
     arguments: ['@console.extension_manager', '@console.translator_manager']

--- a/src/Command/Generate/BlockTypeCommand.php
+++ b/src/Command/Generate/BlockTypeCommand.php
@@ -1,0 +1,349 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Generate\BlockTypeCommand.
+ */
+
+namespace Drupal\Console\Command\Generate;
+
+use Drupal\Console\Command\Shared\ArrayInputTrait;
+use Drupal\Console\Command\Shared\FormTrait;
+use Drupal\Console\Command\Shared\ConfirmationTrait;
+use Drupal\Console\Command\Shared\ModuleTrait;
+use Drupal\Console\Command\Shared\ServicesTrait;
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Core\Utils\StringConverter;
+use Drupal\Console\Core\Utils\ChainQueue;
+use Drupal\Console\Generator\BlockTypeGenerator;
+use Drupal\Console\Extension\Manager;
+use Drupal\Console\Utils\Validator;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\ElementInfoManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block\Entity\Block;
+use Drupal\block_content\BlockContentTypeInterface;
+use Drupal\block_content\Entity\BlockContentType;
+
+class BlockTypeCommand extends ContainerAwareCommand
+{
+    use ArrayInputTrait;
+    use ServicesTrait;
+    use ModuleTrait;
+    use FormTrait;
+    use ConfirmationTrait;
+
+    /**
+     * @var ConfigFactory
+     */
+    protected $configFactory;
+
+    /**
+     * @var ChainQueue
+     */
+    protected $chainQueue;
+
+    /**
+     * @var BlockTypeGenerator
+     */
+    protected $generator;
+
+    /**
+     * @var EntityTypeManagerInterface
+     */
+    protected $entityTypeManager;
+
+    /**
+     * @var Manager
+     */
+    protected $extensionManager;
+
+    /**
+     * @var Validator
+     */
+    protected $validator;
+
+    /**
+     * @var StringConverter
+     */
+    protected $stringConverter;
+
+    /**
+     * @var ElementInfoManagerInterface
+     */
+    protected $elementInfoManager;
+
+    /**
+     * BlockTypeCommand constructor.
+     *
+     * @param ConfigFactory               $configFactory
+     * @param ChainQueue                  $chainQueue
+     * @param BlockTypeGenerator          $generator
+     * @param EntityTypeManagerInterface  $entityTypeManager
+     * @param Manager                     $extensionManager
+     * @param Validator                   $validator
+     * @param StringConverter             $stringConverter
+     * @param ElementInfoManagerInterface $elementInfoManager
+     */
+    public function __construct(
+        ConfigFactory $configFactory,
+        ChainQueue $chainQueue,
+        BlockTypeGenerator $generator,
+        EntityTypeManagerInterface $entityTypeManager,
+        Manager $extensionManager,
+        Validator $validator,
+        StringConverter $stringConverter,
+        ElementInfoManagerInterface $elementInfoManager
+    ) {
+        $this->configFactory = $configFactory;
+        $this->chainQueue = $chainQueue;
+        $this->generator = $generator;
+        $this->entityTypeManager = $entityTypeManager;
+        $this->extensionManager = $extensionManager;
+        $this->validator = $validator;
+        $this->stringConverter = $stringConverter;
+        $this->elementInfoManager = $elementInfoManager;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('generate:block:type')
+            ->setDescription($this->trans('commands.generate.block.type.description'))
+            ->setHelp($this->trans('commands.generate.block.type.help'))
+            ->addOption(
+                'module',
+                null,
+                InputOption::VALUE_REQUIRED,
+                $this->trans('commands.common.options.module')
+            )
+            ->addOption(
+                'class',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.block.type.options.class')
+            )
+            ->addOption(
+                'block-label',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.block.type.options.block-label')
+            )
+            ->addOption(
+                'block-description',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.block.type.options.block-description')
+            )
+            ->addOption(
+                'block-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.block.type.options.block-id')
+            )
+            ->addOption(
+                'theme-region',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                $this->trans('commands.generate.block.type.options.theme-region')
+            )
+            ->addOption(
+                'inputs',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $this->trans('commands.common.options.inputs')
+            )
+            ->addOption(
+                'services',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $this->trans('commands.common.options.services')
+            )
+            ->addOption(
+                'twigtemplate',
+                null,
+                InputOption::VALUE_NONE,
+                $this->trans('commands.generate.block.type.options.twigtemplate')
+            )
+            ->setAliases(['gbt']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // @see use Drupal\Console\Command\Shared\ConfirmationTrait::confirmOperation
+        if (!$this->confirmOperation()) {
+            return 1;
+        }
+
+        $module = $this->validateModule($input->getOption('module'));
+        $class_name = $this->validator->validateClassName($input->getOption('class'));
+        $block_label = $input->getOption('block-label');
+        $block_description = $input->getOption('block-description');
+        $block_id = $input->getOption('block-id');
+        $services = $input->getOption('services');
+        $theme_region = $input->getOption('theme-region');
+        $inputs = $input->getOption('inputs');
+        $noInteraction = $input->getOption('no-interaction');
+        $twigTemplate = $input->getOption('twigtemplate');
+        
+        // Parse nested data.
+        
+        if ($noInteraction) {
+            $inputs = $this->explodeInlineArray($inputs);
+        }
+        
+        $theme = $this->configFactory->get('system.theme')->get('default');
+        $themeRegions = \system_region_list($theme, REGIONS_VISIBLE);
+
+        if (!empty($theme_region) && !isset($themeRegions[$theme_region])) {
+            $this->getIo()->error(
+                sprintf(
+                    $this->trans('commands.generate.block.type.messages.invalid-theme-region'),
+                    $theme_region
+                )
+            );
+
+            return 1;
+        }
+
+        // @see use Drupal\Console\Command\Shared\ServicesTrait::buildServices
+        $build_services = $this->buildServices($services);
+        
+        $theme_region = true;
+        
+        $this->generator->generate([
+          'module' => $module,
+          'class_name' => $class_name,
+          'label' => $block_label,
+          'description' => $block_description,
+          'block_id' => $block_id,
+          'services' => $build_services,
+          'inputs' => $inputs,
+          'twig_template' => $twigTemplate,
+        ]);
+        
+        $this->chainQueue->addCommand('cache:rebuild', ['cache' => 'discovery']);
+
+        if ($theme_region) {
+            $block_content_type = BlockContentType::create([
+              'id' => $block_id,
+              'label' => $block_label,
+              'description' => $block_description,
+            ]);
+            $block_content_type->save();
+
+            $block_content = BlockContent::create([
+              'info' => $block_label,
+              'type' => $block_id,
+              'body' => [
+              'value' => "<h1>Block's body</h1>",
+                'format' => 'full_html',
+               ],
+            ]);
+            
+            $block_content->save();
+        }
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        // --module option
+        $this->getModuleOption();
+
+        // --class option
+        $class = $input->getOption('class');
+        if (!$class) {
+            $class = $this->getIo()->ask(
+                $this->trans('commands.generate.block.type.questions.class'),
+                'DefaultBlock',
+                function ($class) {
+                    return $this->validator->validateClassName($class);
+                }
+            );
+            $input->setOption('class', $class);
+        }
+
+        // --block-label option
+        $block_label = $input->getOption('block-label');
+        if (!$block_label) {
+            $block_label = $this->getIo()->ask(
+                $this->trans('commands.generate.block.type.questions.block-label'),
+                $this->stringConverter->camelCaseToHuman($class)
+            );
+            $input->setOption('block-label', $block_label);
+        }
+
+        // --block-id option
+        $blockId = $input->getOption('block-id');
+        if (!$blockId) {
+            $blockId = $this->getIo()->ask(
+                $this->trans('commands.generate.block.type.questions.block-id'),
+                $this->stringConverter->camelCaseToUnderscore($class)
+            );
+            $input->setOption('block-id', $blockId);
+        }
+        // --block-description option
+        $blockDesc = $input->getOption('block-description');
+        if (!$blockDesc) {
+            $blockDesc = $this->getIo()->ask(
+                $this->trans('commands.generate.block.type.questions.block-description'),
+                $this->stringConverter->camelCaseToUnderscore($class)
+            );
+            $input->setOption('block-description', $blockDesc);
+        }
+        // --theme-region option
+        $themeRegion = $input->getOption('theme-region');
+
+        if (!$themeRegion) {
+            $theme = $this->configFactory->get('system.theme')->get('default');
+            $themeRegions = \system_region_list($theme, REGIONS_VISIBLE);
+            $themeRegionOptions = [];
+            foreach ($themeRegions as $key => $region) {
+                $themeRegionOptions[$key] = $region->render();
+            }
+            $themeRegion = $this->getIo()->choiceNoList(
+                $this->trans('commands.generate.block.type.questions.theme-region'),
+                $themeRegionOptions,
+                '',
+                true
+            );
+            $themeRegion = array_search($themeRegion, $themeRegions);
+            $input->setOption('theme-region', $themeRegion);
+        }
+
+        // --services option
+        // @see Drupal\Console\Command\Shared\ServicesTrait::servicesQuestion
+        $services = $this->servicesQuestion();
+        $input->setOption('services', $services);
+
+        $output->writeln($this->trans('commands.generate.block.type.messages.inputs'));
+
+        // --inputs option
+        $inputs = $input->getOption('inputs');
+        if (!$inputs) {
+            // @see \Drupal\Console\Command\Shared\FormTrait::formQuestion
+            $inputs = $this->formQuestion();
+            $input->setOption('inputs', $inputs);
+        } else {
+            $inputs = $this->explodeInlineArray($inputs);
+        }
+        $input->setOption('inputs', $inputs);
+
+        $twigtemplate = $input->getOption('twigtemplate');
+        if (!$twigtemplate) {
+            $twigtemplate = $this->getIo()->confirm(
+                $this->trans('commands.generate.block.type.questions.twigtemplate'),
+                false
+            );
+            $input->setOption('twigtemplate', $twigtemplate);
+        }
+    }
+}

--- a/src/Generator/BlockTypeGenerator.php
+++ b/src/Generator/BlockTypeGenerator.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Generator\BlockTypeGenerator.
+ */
+
+namespace Drupal\Console\Generator;
+
+use Drupal\Console\Core\Generator\Generator;
+use Drupal\Console\Extension\Manager;
+
+class BlockTypeGenerator extends Generator
+{
+    /**
+     * @var Manager
+     */
+    protected $extensionManager;
+
+    /**
+     * PermissionGenerator constructor.
+     *
+     * @param Manager $extensionManager
+     */
+    public function __construct(
+        Manager $extensionManager
+    ) {
+        $this->extensionManager = $extensionManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(array $parameters)
+    {
+
+        $inputs = $parameters['inputs'];
+        $module = $parameters['module'];
+        $class_name = $parameters['class_name'];
+        $twigTemplate = $parameters['twig_template'];
+        $blockId = $parameters['block_id'];
+        $description = $parameters['block_description'];
+        $parameters['twig_template_name'] = str_replace('_', '-', $blockId);
+        $parameters['machine_name'] = $blockId;
+
+        $this->renderFile(
+            'module/src/Plugin/Block/blocktype.php.twig',
+            $this->extensionManager->getPluginPath($module, 'Block') . '/' . $class_name . '.php',
+            $parameters
+        );
+
+        if ($twigTemplate) {
+            $moduleDirectory = $this->extensionManager->getModule($module)->getPath();
+            $moduleFilePath = $moduleDirectory . '/' . $module . '.module';
+
+            $parameters['file_exist'] = file_exists($moduleFilePath);
+
+            $this->renderFile(
+                'module/module-block-twig-template-append.twig',
+                $moduleFilePath,
+                $parameters,
+                FILE_APPEND
+            );
+            $moduleDirectory .= '/templates/';
+            if (file_exists($moduleDirectory)) {
+                if (!is_dir($moduleDirectory)) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'Unable to generate the templates directory as the target directory "%s" exists but is a file.',
+                            realpath($moduleDirectory)
+                        )
+                    );
+                }
+                if (!is_writable($moduleDirectory)) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'Unable to generate the templates directory as the target directory "%s" is not writable.',
+                            realpath($moduleDirectory)
+                        )
+                    );
+                }
+            }
+            $this->renderFile(
+                'module/templates/block-type-html.twig',
+                $moduleDirectory . $parameters['twig_template_name'] . '.html.twig',
+                $parameters
+            );
+        }
+    }
+}

--- a/src/Generator/BlockTypeGenerator.php
+++ b/src/Generator/BlockTypeGenerator.php
@@ -34,13 +34,10 @@ class BlockTypeGenerator extends Generator
     public function generate(array $parameters)
     {
 
-        $inputs = $parameters['inputs'];
         $module = $parameters['module'];
         $class_name = $parameters['class_name'];
-        $twigTemplate = $parameters['twig_template'];
         $blockId = $parameters['block_id'];
         $description = $parameters['block_description'];
-        $parameters['twig_template_name'] = str_replace('_', '-', $blockId);
         $parameters['machine_name'] = $blockId;
 
         $this->renderFile(
@@ -49,42 +46,5 @@ class BlockTypeGenerator extends Generator
             $parameters
         );
 
-        if ($twigTemplate) {
-            $moduleDirectory = $this->extensionManager->getModule($module)->getPath();
-            $moduleFilePath = $moduleDirectory . '/' . $module . '.module';
-
-            $parameters['file_exist'] = file_exists($moduleFilePath);
-
-            $this->renderFile(
-                'module/module-block-twig-template-append.twig',
-                $moduleFilePath,
-                $parameters,
-                FILE_APPEND
-            );
-            $moduleDirectory .= '/templates/';
-            if (file_exists($moduleDirectory)) {
-                if (!is_dir($moduleDirectory)) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'Unable to generate the templates directory as the target directory "%s" exists but is a file.',
-                            realpath($moduleDirectory)
-                        )
-                    );
-                }
-                if (!is_writable($moduleDirectory)) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'Unable to generate the templates directory as the target directory "%s" is not writable.',
-                            realpath($moduleDirectory)
-                        )
-                    );
-                }
-            }
-            $this->renderFile(
-                'module/templates/block-type-html.twig',
-                $moduleDirectory . $parameters['twig_template_name'] . '.html.twig',
-                $parameters
-            );
-        }
     }
 }

--- a/templates/module/src/Plugin/Block/blocktype.php.twig
+++ b/templates/module/src/Plugin/Block/blocktype.php.twig
@@ -1,0 +1,153 @@
+{% extends "base/class.php.twig" %}
+
+{% block file_path %}
+\Drupal\{{module}}\Plugin\Block\{{class_name}}.
+{% endblock %}
+
+{% block namespace_class %}
+namespace Drupal\{{module}}\Plugin\Block;
+{% endblock %}
+
+{% block use_class %}
+use Drupal\Core\Block\BlockBase;
+{% if inputs %}
+use Drupal\Core\Form\FormStateInterface;
+{% endif %}
+{% if services is not empty %}
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+{% endif %}
+{% endblock %}
+
+{% block class_declaration %}
+/**
+ * Provides a '{{class_name}}' block.
+ *
+ * @Block(
+ *  id = "{{block_id}}",
+ *  admin_label = @Translation("{{label}}"),
+ * )
+ */
+class {{class_name}} extends BlockBase {% if services is not empty %}implements ContainerFactoryPluginInterface {% endif %}{% endblock %}
+{% block class_construct %}
+{% if services is not empty %}
+  /**
+   * Constructs a new {{class_name}} object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $block_id
+   *   The block_id for the block instance.
+   * @param string $_definition
+   *   The block implementation definition.
+{% if services is not empty %}
+{% for service in services %}
+   * @param \{{ service.class }} ${{service.machine_name}}
+   *   The {{service.short}} definition.
+{% endfor %}
+{% endif %}
+   */
+  public function __construct(
+    array $configuration,
+    $block_id,
+    $block_definition,
+    {{ servicesAsParameters(services)|join(',\n    ') }}
+  ) {
+    parent::__construct($configuration, $block_id, $block_definition);
+{{ serviceClassInitialization(services) }}
+  }
+{% endif %}
+{% endblock %}
+{% block class_create %}
+{% if services is not empty %}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $block_id, $block_definition) {
+    return new static(
+      $configuration,
+      $block_id,
+      $block_definition,
+{{ serviceClassInjection(services) }}
+    );
+  }
+
+{% endif %}
+{% endblock %}
+{% block class_methods %}
+{% if inputs %}
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+{% for input in inputs %}
+{% if input.default_value is defined and input.default_value|length %}
+      '{{ input.name }}' => {{ input.default_value }},
+{% endif %}
+{% endfor %}
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+{% for input in inputs %}
+    $form['{{ input.name }}'] = [
+      '#type' => '{{ input.type }}',
+      '#title' => $this->t('{{ input.label|escape }}'),
+{% if input.description is defined and input.description is not empty %}
+      '#description' => $this->t('{{ input.description|e }}'),
+{% endif %}
+{% if input.options is defined and input.options|length %}
+      '#options' => {{ input.options }},
+{% endif %}
+      '#default_value' => $this->configuration['{{ input.name }}'],
+{% if input.maxlength is defined and input.maxlength|length %}
+      '#maxlength' => {{ input.maxlength }},
+{% endif %}
+{% if input.size is defined and input.size|length %}
+      '#size' => {{ input.size }},
+{% endif %}
+{% if input.weight is defined and input.weight|length %}
+      '#weight' => '{{ input.weight }}',
+{% endif %}
+    ];
+{% endfor %}
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+{% for input in inputs %}
+    $this->configuration['{{ input.name }}'] = $form_state->getValue('{{ input.name }}'){% if input.type == 'text_format' %}['value']{% endif %};
+{% endfor %}
+  }
+
+{% endif %}
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+{% if twig_template is defined %}
+    $build['#theme'] = '{{ block_id }}';
+{% endif %}
+{% for input in inputs %}
+{% if twig_template is defined %}
+    $build['#conten'][] = $this->configuration['{{ input.name }}'];
+{% else %}
+    $build['{{block_id}}_{{ input.name }}']['#markup'] = '<p>' . $this->configuration['{{ input.name }}'] . '</p>';
+{% endif %}
+{% else %}
+     $build['{{block_id}}']['#markup'] = 'Implement {{class_name}}.';
+{% endfor %}
+
+    return $build;
+  }
+{% endblock %}

--- a/templates/module/src/Plugin/Block/blocktype.php.twig
+++ b/templates/module/src/Plugin/Block/blocktype.php.twig
@@ -10,144 +10,16 @@ namespace Drupal\{{module}}\Plugin\Block;
 
 {% block use_class %}
 use Drupal\Core\Block\BlockBase;
-{% if inputs %}
-use Drupal\Core\Form\FormStateInterface;
-{% endif %}
-{% if services is not empty %}
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-{% endif %}
 {% endblock %}
 
 {% block class_declaration %}
-/**
- * Provides a '{{class_name}}' block.
- *
- * @Block(
- *  id = "{{block_id}}",
- *  admin_label = @Translation("{{label}}"),
- * )
- */
-class {{class_name}} extends BlockBase {% if services is not empty %}implements ContainerFactoryPluginInterface {% endif %}{% endblock %}
-{% block class_construct %}
-{% if services is not empty %}
-  /**
-   * Constructs a new {{class_name}} object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $block_id
-   *   The block_id for the block instance.
-   * @param string $_definition
-   *   The block implementation definition.
-{% if services is not empty %}
-{% for service in services %}
-   * @param \{{ service.class }} ${{service.machine_name}}
-   *   The {{service.short}} definition.
-{% endfor %}
-{% endif %}
-   */
-  public function __construct(
-    array $configuration,
-    $block_id,
-    $block_definition,
-    {{ servicesAsParameters(services)|join(',\n    ') }}
-  ) {
-    parent::__construct($configuration, $block_id, $block_definition);
-{{ serviceClassInitialization(services) }}
-  }
-{% endif %}
-{% endblock %}
-{% block class_create %}
-{% if services is not empty %}
 
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $block_id, $block_definition) {
-    return new static(
-      $configuration,
-      $block_id,
-      $block_definition,
-{{ serviceClassInjection(services) }}
-    );
-  }
-
-{% endif %}
-{% endblock %}
-{% block class_methods %}
-{% if inputs %}
-  /**
-   * {@inheritdoc}
-   */
-  public function defaultConfiguration() {
-    return [
-{% for input in inputs %}
-{% if input.default_value is defined and input.default_value|length %}
-      '{{ input.name }}' => {{ input.default_value }},
-{% endif %}
-{% endfor %}
-    ] + parent::defaultConfiguration();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function blockForm($form, FormStateInterface $form_state) {
-{% for input in inputs %}
-    $form['{{ input.name }}'] = [
-      '#type' => '{{ input.type }}',
-      '#title' => $this->t('{{ input.label|escape }}'),
-{% if input.description is defined and input.description is not empty %}
-      '#description' => $this->t('{{ input.description|e }}'),
-{% endif %}
-{% if input.options is defined and input.options|length %}
-      '#options' => {{ input.options }},
-{% endif %}
-      '#default_value' => $this->configuration['{{ input.name }}'],
-{% if input.maxlength is defined and input.maxlength|length %}
-      '#maxlength' => {{ input.maxlength }},
-{% endif %}
-{% if input.size is defined and input.size|length %}
-      '#size' => {{ input.size }},
-{% endif %}
-{% if input.weight is defined and input.weight|length %}
-      '#weight' => '{{ input.weight }}',
-{% endif %}
-    ];
-{% endfor %}
-
-    return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function blockSubmit($form, FormStateInterface $form_state) {
-{% for input in inputs %}
-    $this->configuration['{{ input.name }}'] = $form_state->getValue('{{ input.name }}'){% if input.type == 'text_format' %}['value']{% endif %};
-{% endfor %}
-  }
-
-{% endif %}
   /**
    * {@inheritdoc}
    */
   public function build() {
     $build = [];
-{% if twig_template is defined %}
-    $build['#theme'] = '{{ block_id }}';
-{% endif %}
-{% for input in inputs %}
-{% if twig_template is defined %}
-    $build['#conten'][] = $this->configuration['{{ input.name }}'];
-{% else %}
-    $build['{{block_id}}_{{ input.name }}']['#markup'] = '<p>' . $this->configuration['{{ input.name }}'] . '</p>';
-{% endif %}
-{% else %}
-     $build['{{block_id}}']['#markup'] = 'Implement {{class_name}}.';
-{% endfor %}
-
+    $build['{{block_id}}']['#markup'] = 'Implement {{class_name}}.';
     return $build;
   }
 {% endblock %}


### PR DESCRIPTION
New command in order to generate a block content type and block type.

```$ drupal generate:block:type```
Additional the next https://github.com/hechoendrupal/drupal-console-en/pull/254
**Using**
Drupal Console        : 1.9.3
Drupal Console-en  : 1.9.3
Drupal core              : 8.7.7

Results Command.
1. ![blocktype](https://user-images.githubusercontent.com/6983125/65738650-38961c00-e0a8-11e9-9597-38cc30158f66.png)
2. ![blockcustom](https://user-images.githubusercontent.com/6983125/65738649-38961c00-e0a8-11e9-85ff-a7e84bc3c506.png)

Watch the video

https://youtu.be/xbx-dM1fT6I