### PR TITLE
Removes constructor override on service object generators.

### DIFF
--- a/templates/module/src/Controller/controller.php.twig
+++ b/templates/module/src/Controller/controller.php.twig
@@ -14,32 +14,23 @@ use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
+{% block use_class_services %}
+{% endblock %}
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
  */
 class {{ class_name }} extends ControllerBase {% endblock %}
-{% block class_construct %}
-{% if services is not empty %}
 
-  /**
-   * Constructs a new {{ class_name }} object.
-   */
-  public function __construct({{ servicesAsParameters(services)|join(', ') }}) {
-{{ serviceClassInitialization(services) }}
-  }
-{% endif %}
-{% endblock %}
 {% block class_create %}
 {% if services is not empty %}
-
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-{{ serviceClassInjection(services) }}
-    );
+    $instance = parent::create($container);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 
 {% endif %}

--- a/templates/module/src/Controller/controller.php.twig
+++ b/templates/module/src/Controller/controller.php.twig
@@ -14,8 +14,10 @@ use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
+
 {% block use_class_services %}
 {% endblock %}
+
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.

--- a/templates/module/src/Controller/entity-controller.php.twig
+++ b/templates/module/src/Controller/entity-controller.php.twig
@@ -11,9 +11,7 @@ namespace Drupal\{{ module }}\Controller;
 {% block use_class %}
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Render\Renderer;
 use Drupal\Core\Url;
 use Drupal\{{ module }}\Entity\{{ entity_class }}Interface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -26,7 +24,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class {{ entity_class }}Controller extends ControllerBase implements ContainerInjectionInterface {% endblock %}
 {% block class_methods %}
-
   /**
    * The date formatter.
    *
@@ -42,26 +39,13 @@ class {{ entity_class }}Controller extends ControllerBase implements ContainerIn
   protected $renderer;
 
   /**
-   * Constructs a new {{ entity_class }}Controller.
-   *
-   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
-   *   The date formatter.
-   * @param \Drupal\Core\Render\Renderer $renderer
-   *   The renderer.
-   */
-  public function __construct(DateFormatter $date_formatter, Renderer $renderer) {
-    $this->dateFormatter = $date_formatter;
-    $this->renderer = $renderer;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('date.formatter'),
-      $container->get('renderer')
-    );
+    $instance = parent::create($container);
+    $instance->dateFormatter = $container->get('date.formatter');
+    $instance->renderer = $container->get('renderer');
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
@@ -9,8 +9,6 @@ namespace Drupal\{{module}}\Form;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Database\Connection;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -25,7 +23,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %}
 {% block class_methods %}
-
   /**
    * The {{ label }} revision.
    *
@@ -38,7 +35,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
    *
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
-  protected ${{ entity_class }}Storage;
+  protected ${{ entity_class[:1]|lower ~ entity_class[1:] }}Storage;
 
   /**
    * The database connection.
@@ -48,27 +45,13 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
   protected $connection;
 
   /**
-   * Constructs a new {{ entity_class }}RevisionDeleteForm.
-   *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
-   *   The entity storage.
-   * @param \Drupal\Core\Database\Connection $connection
-   *   The database connection.
-   */
-  public function __construct(EntityStorageInterface $entity_storage, Connection $connection) {
-    $this->{{ entity_class }}Storage = $entity_storage;
-    $this->connection = $connection;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    $entity_type_manager = $container->get('entity_type.manager');
-    return new static(
-      $entity_type_manager->getStorage('{{ entity_name }}'),
-      $container->get('database')
-    );
+    $instance = parent::create($container);
+    $instance->{{ entity_class[:1]|lower ~ entity_class[1:] }}Storage = $container->get('entity_type.manager')->getStorage('{{ entity_name }}');
+    $instance->connection = $container->get('database');
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
@@ -9,10 +9,7 @@ namespace Drupal\{{module}}\Form;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Datetime\DateFormatterInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\{{module}}\Entity\{{ entity_class }}Interface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endblock %}
@@ -25,7 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class {{ entity_class }}RevisionRevertTranslationForm extends {{ entity_class }}RevisionRevertForm {% endblock %}
 {% block class_methods %}
-
   /**
    * The language to be reverted.
    *
@@ -41,29 +37,12 @@ class {{ entity_class }}RevisionRevertTranslationForm extends {{ entity_class }}
   protected $languageManager;
 
   /**
-   * Constructs a new {{ entity_class }}RevisionRevertTranslationForm.
-   *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
-   *   The {{ label }} storage.
-   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
-   *   The date formatter service.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager.
-   */
-  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter, LanguageManagerInterface $language_manager) {
-    parent::__construct($entity_storage, $date_formatter);
-    $this->languageManager = $language_manager;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')->getStorage('{{ entity_name }}'),
-      $container->get('date.formatter'),
-      $container->get('language_manager')
-    );
+    $instance = parent::create($container);
+    $instance->languageManager = $container->get('language_manager');
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
@@ -9,8 +9,6 @@ namespace Drupal\{{module}}\Form;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Datetime\DateFormatterInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -26,7 +24,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %}
 {% block class_methods %}
-
   /**
    * The {{ label }} revision.
    *
@@ -39,7 +36,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
    *
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
-  protected ${{ entity_class }}Storage;
+  protected ${{ entity_class[:1]|lower ~ entity_class[1:] }}Storage;
 
   /**
    * The date formatter service.
@@ -49,26 +46,13 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
   protected $dateFormatter;
 
   /**
-   * Constructs a new {{ entity_class }}RevisionRevertForm.
-   *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
-   *   The {{ label }} storage.
-   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
-   *   The date formatter service.
-   */
-  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter) {
-    $this->{{ entity_class }}Storage = $entity_storage;
-    $this->dateFormatter = $date_formatter;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')->getStorage('{{ entity_name }}'),
-      $container->get('date.formatter')
-    );
+    $instance = parent::create($container);
+    $instance->{{ entity_class[:1]|lower ~ entity_class[1:] }}Storage = $container->get('entity_type.manager')->getStorage('{{ entity_name }}');
+    $instance->dateFormatter = $container->get('date.formatter');
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Entity/Form/entity-content.php.twig
+++ b/templates/module/src/Entity/Form/entity-content.php.twig
@@ -9,12 +9,8 @@ namespace Drupal\{{module}}\Form;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endblock %}
 
@@ -34,34 +30,13 @@ class {{ entity_class }}Form extends ContentEntityForm {% endblock %}
   protected $account;
 
   /**
-   * Constructs a new {{ entity_class }}Form.
-   *
-   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
-   *   The entity repository service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\Session\AccountProxyInterface $account
-   *   The current user account.
-   */
-  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL, AccountProxyInterface $account) {
-    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
-
-    $this->account = $account;
-  }
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     // Instantiates this form class.
-    return new static(
-      $container->get('entity.repository'),
-      $container->get('entity_type.bundle.info'),
-      $container->get('datetime.time'),
-      $container->get('current_user')
-    );
+    $instance = parent::create($container);
+    $instance->account = $container->get('current_user');
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -15,8 +15,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
+
 {% block use_class_services %}
 {% endblock %}
+
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.

--- a/templates/module/src/Form/form-config.php.twig
+++ b/templates/module/src/Form/form-config.php.twig
@@ -12,31 +12,16 @@ namespace Drupal\{{module_name}}\Form;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 {% if services is not empty %}
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
-
+{% block use_class_services %}
+{% endblock %}
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
  */
 class {{ class_name }} extends ConfigFormBase {% endblock %}
-{% block class_construct %}
-{% if services is not empty %}
-  /**
-   * Constructs a new {{ class_name }} object.
-   */
-  public function __construct(
-    ConfigFactoryInterface $config_factory,
-    {{ servicesAsParameters(services)|join(',\n    ') }}
-  ) {
-    parent::__construct($config_factory);
-{{ serviceClassInitialization(services) }}
-  }
-
-{% endif %}
-{% endblock %}
 
 {% block class_create %}
 {% if services is not empty %}
@@ -44,10 +29,9 @@ class {{ class_name }} extends ConfigFormBase {% endblock %}
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-{{ serviceClassInjection(services) }}
-    );
+    $instance = parent::create($container);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 
 {% endif %}

--- a/templates/module/src/Form/form.php.twig
+++ b/templates/module/src/Form/form.php.twig
@@ -16,25 +16,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
 
+{% block use_class_services %}
+{% endblock %}
+
 {% block class_declaration %}
 /**
  * Class {{ class_name }}.
  */
 class {{ class_name }} extends FormBase {% endblock %}
-
-{% block class_construct %}
-{% if services is not empty %}
-  /**
-   * Constructs a new {{ class_name }} object.
-   */
-  public function __construct(
-    {{ servicesAsParameters(services)|join(',\n    ') }}
-  ) {
-{{ serviceClassInitialization(services) }}
-  }
-
-{% endif %}
-{% endblock %}
 
 {% block class_create %}
 {% if services is not empty %}
@@ -42,9 +31,9 @@ class {{ class_name }} extends FormBase {% endblock %}
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-{{ serviceClassInjection(services) }}
-    );
+    $instance = parent::create($container);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 
 {% endif %}

--- a/templates/module/src/Plugin/Block/block.php.twig
+++ b/templates/module/src/Plugin/Block/block.php.twig
@@ -19,6 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
 
+{% block use_class_services %}
+{% endblock %}
+
 {% block class_declaration %}
 /**
  * Provides a '{{class_name}}' block.
@@ -29,48 +32,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class {{class_name}} extends BlockBase {% if services is not empty %}implements ContainerFactoryPluginInterface {% endif %}{% endblock %}
-{% block class_construct %}
-{% if services is not empty %}
-  /**
-   * Constructs a new {{class_name}} object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param string $plugin_definition
-   *   The plugin implementation definition.
-{% if services is not empty %}
-{% for service in services %}
-   * @param \{{ service.class }} ${{service.machine_name}}
-   *   The {{service.short}} definition.
-{% endfor %}
-{% endif %}
-   */
-  public function __construct(
-    array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    {{ servicesAsParameters(services)|join(',\n    ') }}
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-{{ serviceClassInitialization(services) }}
-  }
-{% endif %}
-{% endblock %}
+
 {% block class_create %}
 {% if services is not empty %}
-
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-{{ serviceClassInjection(services) }}
-    );
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 
 {% endif %}

--- a/templates/module/src/Plugin/Condition/condition.php.twig
+++ b/templates/module/src/Plugin/Condition/condition.php.twig
@@ -33,28 +33,8 @@ class {{ class_name }} extends ConditionPluginBase {% endblock %}
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition
-    );
-  }
-
-  /**
-   * Creates a new {{ class_name }} object.
-   *
-   * @param array $configuration
-   *   The plugin configuration, i.e. an array with configuration values keyed
-   *   by configuration option name. The special key 'context' may be used to
-   *   initialize the defined contexts by setting it to an array of context
-   *   values keyed by context names.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    return $instance;
   }
 
   /**

--- a/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
+++ b/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
@@ -10,13 +10,9 @@ namespace Drupal\{{ module }}\Plugin\Field\FieldFormatter;
 
 {% block use_class %}
 use Drupal\image\Plugin\Field\FieldFormatter\ImageFormatterBase;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Utility\LinkGeneratorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Cache\Cache;
@@ -36,75 +32,37 @@ use Drupal\Core\Cache\Cache;
  */
 class {{ class_name }} extends ImageFormatterBase implements ContainerFactoryPluginInterface {% endblock %}
 {% block class_methods %}
-/**
- * The current user.
- *
- * @var \Drupal\Core\Session\AccountInterface
- */
- protected $currentUser;
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
 
-/**
- * The link generator.
- *
- * @var \Drupal\Core\Utility\LinkGeneratorInterface
- */
- protected $linkGenerator;
+  /**
+   * The link generator.
+   *
+   * @var \Drupal\Core\Utility\LinkGeneratorInterface
+   */
+  protected $linkGenerator;
 
-/**
- * The image style entity storage.
- *
- * @var \Drupal\Core\Entity\EntityStorageInterface
- */
- protected $imageStyleStorage;
+  /**
+   * The image style entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $imageStyleStorage;
 
-/**
- * Constructs a new {{ class_name }} object.
- *
- * @param string $plugin_id
- *   The plugin_id for the formatter.
- * @param mixed $plugin_definition
- *   The plugin implementation definition.
- * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
- *   The definition of the field to which the formatter is associated.
- * @param array $settings
- *   The formatter settings.
- * @param string $label
- *   The formatter label display setting.
- * @param string $view_mode
- *   The view mode.
- * @param array $third_party_settings
- *   Any third party settings settings.
- * @param \Drupal\Core\Session\AccountInterface $current_user
- *   The current user.
- * @param \Drupal\Core\Utility\LinkGeneratorInterface $link_generator
- *   The link generator service.
- * @param \Drupal\Core\Entity\EntityStorageInterface $image_style_storage
- *   The entity storage for the image.
- */
- public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, AccountInterface $current_user, LinkGeneratorInterface $link_generator, EntityStorageInterface $image_style_storage) {
-    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-    $this->currentUser = $current_user;
-    $this->linkGenerator = $link_generator;
-    $this->imageStyleStorage = $image_style_storage;
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->currentUser = $container->get('current_user');
+    $instance->linkGenerator = $container->get('link_generator');
+    $instance->imageStyleStorage = $container->get('entity_type.manager')->getStorage('image_style');
+    return $instance;
   }
-
-/**
- * {@inheritdoc}
- */
- public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-   return new static(
-     $plugin_id,
-     $plugin_definition,
-     $configuration['field_definition'],
-     $configuration['settings'],
-     $configuration['label'],
-     $configuration['view_mode'],
-     $configuration['third_party_settings'],
-     $container->get('current_user'),
-     $container->get('link_generator'),
-     $container->get('entity_type.manager')->getStorage('image_style')
-   );
- }
 
 /**
  * {@inheritdoc}

--- a/templates/module/src/Plugin/Mail/mail.php.twig
+++ b/templates/module/src/Plugin/Mail/mail.php.twig
@@ -16,6 +16,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
 
+{% block use_class_services %}
+{% endblock %}
+
 {% block class_declaration %}
 /**
  * Provides a '{{class_name}}' mail plugin.
@@ -28,43 +31,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class {{class_name}} extends PhpMail {% if services is not empty %}implements ContainerFactoryPluginInterface {% endif %}
 {% endblock %}
 
-{% block class_construct %}
-{% if services is not empty %}
-  /**
-   * Constructs a new {{class_name}} object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param string $plugin_definition
-   *   The plugin implementation definition.
-   */
-  public function __construct(
-        array $configuration,
-        $plugin_id,
-        $plugin_definition,
-        {{ servicesAsParameters(services)|join(', \n\t') }}
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-{{ serviceClassInitialization(services) }}
-  }
-
-{% endif %}
-{% endblock %}
-
 {% block class_create %}
 {% if services is not empty %}
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-{{ serviceClassInjection(services) }}
-    );
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 {% endif %}
 {% endblock %}

--- a/templates/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/templates/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -9,11 +9,9 @@ namespace Drupal\{{module_name}}\Plugin\rest\resource;
 {% endblock %}
 
 {% block use_class %}
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\rest\ModifiedResourceResponse;
 use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\ResourceResponse;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 {% endblock %}
@@ -35,60 +33,25 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 class {{ class_name }} extends ResourceBase {% endblock %}
 
 {% block class_variables %}
-    /**
-     * A current user instance.
-     *
-     * @var \Drupal\Core\Session\AccountProxyInterface
-     */
-    protected $currentUser;
-{% endblock %}
-
-{% block class_construct %}
-
-    /**
-     * Constructs a new {{ class_name }} object.
-     *
-     * @param array $configuration
-     *   A configuration array containing information about the plugin instance.
-     * @param string $plugin_id
-     *   The plugin_id for the plugin instance.
-     * @param mixed $plugin_definition
-     *   The plugin implementation definition.
-     * @param array $serializer_formats
-     *   The available serialization formats.
-     * @param \Psr\Log\LoggerInterface $logger
-     *   A logger instance.
-     * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-     *   A current user instance.
-     */
-    public function __construct(
-        array $configuration,
-        $plugin_id,
-        $plugin_definition,
-        array $serializer_formats,
-        LoggerInterface $logger,
-        AccountProxyInterface $current_user) {
-        parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
-
-        $this->currentUser = $current_user;
-    }
+  /**
+   * A current user instance.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
 {% endblock %}
 
 {% block class_create %}
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-        return new static(
-            $configuration,
-            $plugin_id,
-            $plugin_definition,
-            $container->getParameter('serializer.formats'),
-            $container->get('logger.factory')->get('{{module_name}}'),
-            $container->get('current_user')
-        );
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->logger = $container->get('logger.factory')->get('{{module_name}}');
+    $instance->currentUser = $container->get('current_user');
+    return $instance;
+  }
 {% endblock %}
 
 {% block class_methods %}

--- a/templates/module/src/Plugin/skeleton.php.twig
+++ b/templates/module/src/Plugin/skeleton.php.twig
@@ -19,6 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 {% endif %}
 {% endblock %}
 
+{% block use_class_services %}
+{% endblock %}
+
 {% block class_declaration %}
 {% if pluginAnnotation is not empty %}
 /**
@@ -36,44 +39,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 {% endif %}
 class {{class_name}} implements {% if plugin_interface is not empty %}{{ plugin_interface }}{% endif %}{% if services is not empty %}, ContainerFactoryPluginInterface {% endif %}{% endblock %}
-{% block class_construct %}
+
+{% block class_create %}
 {% if services is not empty %}
   /**
-   * Constructs a new {{class_name}} object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param string $plugin_definition
-   *   The plugin implementation definition.
+   * {@inheritdoc}
    */
-  public function __construct(
-        array $configuration,
-        $plugin_id,
-        $plugin_definition,
-        {{ servicesAsParameters(services)|join(', \n\t') }}
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-{{ serviceClassInitialization(services) }}
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+{{ serviceClassInjectionNoOverride(services) }}
+    return $instance;
   }
 {% endif %}
 {% endblock %}
-{% block class_create %}
-{% if services is not empty %}
-    /**
-     * {@inheritdoc}
-     */
-    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-        return new static(
-            $configuration,
-            $plugin_id,
-            $plugin_definition,
-            {{ serviceClassInjection(services) }}
-        );
-    }
-{% endif %}
-{% endblock %}
+
 {% block class_methods %}
 
     /**


### PR DESCRIPTION
This addresses https://github.com/hechoendrupal/drupal-console/issues/4169. 

It requires https://github.com/hechoendrupal/drupal-console-core/pull/369 to be merged first, for a few of the generators that use the function Twig function `serviceClassInjection`.