### PR TITLE
[generate:theme] fix libraries.yml syntax

### DIFF
--- a/templates/theme/libraries.yml.twig
+++ b/templates/theme/libraries.yml.twig
@@ -7,7 +7,7 @@
      #js/your_js.js : {}
 {% for library in libraries %}
 {{ library.library_name }}:
-  version: {{ library.library_version }}
+   version: {{ library.library_version }}
    css:
     theme:
       #js/your_js.js : {}


### PR DESCRIPTION
There is an indexation error in the template, the generated file is invalid