### PR TITLE
[site:install] Regression: command does not respect empty db-prefix

### DIFF
--- a/src/Command/Site/InstallCommand.php
+++ b/src/Command/Site/InstallCommand.php
@@ -323,7 +323,7 @@ class InstallCommand extends ContainerAwareCommand
             }
 
             // --db-prefix option
-            if (!$input->getOption('db-prefix')) {
+            if ($input->getOption('db-prefix') === null) {
                 $input->setOption('db-prefix', $this->dbPrefixQuestion());
             }
         }


### PR DESCRIPTION
### Problem/Motivation
The issue that was addressed in commit e62a1fe #3930 #3931 is back.

If you submit an empty string as DB prefix (`--db-prefix=''`) it is handled exactly as if no db-prefix was given: the command asks for a prefix regardless of the input. This is due to a regression first introduced by f1dc3aa #3917. This regression was partly reverted by 1247f20 #4049, but in both cases **PHP’s implicit type casting** causes problems.

You have to check the input value explicitly against `null`, otherwise a blank string ("no prefix") will be handled like "no value given".

```php
if (!$something) {
    echo '$something is either null or 0 or false or an empty array or an empty string. Are you sure this is the desired behavior?';
}
```

### How to reproduce
- Drupal version: tested on Drupal 8.6+
- Console version: Regression was introduced in 1.9.1

```shell-script
drupal -y si test \
    --langcode="en" \
    --db-type="mysql" \
    --db-host="testdbhost" \
    --db-port="3306" \
    --db-name="testdb" \
    --db-user="testuser" \
    --db-pass="testpass" \
    --db-prefix="" \
    --account-name=admin \
    --account-pass=admin \
    --account-mail=admin@example.com \
    --site-name="Test (MySQL)" \
    --site-mail="admin@example.com"
```

Result:

```plaintext
 Database Prefix []:
 >
```

### Solution
Avoid implicit type casting and check `$input->getOption('db-prefix')` against `null` explicitly.
