### PR TITLE
Bugfix for #4174.

### DIFF
--- a/templates/module/src/Plugin/Block/block.php.twig
+++ b/templates/module/src/Plugin/Block/block.php.twig
@@ -39,7 +39,7 @@ class {{class_name}} extends BlockBase {% if services is not empty %}implements 
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
 {{ serviceClassInjectionNoOverride(services) }}
     return $instance;
   }

--- a/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
+++ b/templates/module/src/Plugin/Field/FieldFormatter/imageformatter.php.twig
@@ -57,7 +57,7 @@ class {{ class_name }} extends ImageFormatterBase implements ContainerFactoryPlu
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->currentUser = $container->get('current_user');
     $instance->linkGenerator = $container->get('link_generator');
     $instance->imageStyleStorage = $container->get('entity_type.manager')->getStorage('image_style');

--- a/templates/module/src/Plugin/Mail/mail.php.twig
+++ b/templates/module/src/Plugin/Mail/mail.php.twig
@@ -37,7 +37,7 @@ class {{class_name}} extends PhpMail {% if services is not empty %}implements Co
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
 {{ serviceClassInjectionNoOverride(services) }}
     return $instance;
   }

--- a/templates/module/src/Plugin/skeleton.php.twig
+++ b/templates/module/src/Plugin/skeleton.php.twig
@@ -46,7 +46,7 @@ class {{class_name}} implements {% if plugin_interface is not empty %}{{ plugin_
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
 {{ serviceClassInjectionNoOverride(services) }}
     return $instance;
   }


### PR DESCRIPTION
There was a bug on some of the templates on the previous PR I made.
When the class itself is implementing ContainerFactoryPluginInterface, there's no parent create method we can use. We should fallback to the class __construct() method instad.
This PR does just that.