### PR TITLE
[generate:plugin:field] Missing coma in fieldwidget.php.twig

### DIFF
--- a/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
+++ b/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @FieldWidget(
  *   id = "{{ plugin_id }}",
- *   module = "{{ module }}"
+ *   module = "{{ module }}",
  *   label = @Translation("{{ label }}"){% if field_type %},
  *   field_types = {
  *     "{{ field_type }}"


### PR DESCRIPTION
Throw Doctrine\Common\Annotations\AnnotationException