### PR TITLE
[generate:plugin:ckeditorbutton] Fix spelling error of variable in plugin.php.twig

### DIFF
--- a/templates/module/src/Plugin/CKEditorPlugin/plugin.php.twig
+++ b/templates/module/src/Plugin/CKEditorPlugin/plugin.php.twig
@@ -5,7 +5,7 @@
 * @preserve
 **/
 {% for button in buttons %}
-CKEDITOR.plugins.add('{{ pligins_id }}', {
+CKEDITOR.plugins.add('{{ plugin_id }}', {
     init: function( editor ) {
         if ( editor.ui.addButton ) {
             editor.ui.addButton( '{{ button.name }}', {


### PR DESCRIPTION
Fix for issue #4203 