### PR TITLE
Update links.task-entity-content.yml.twig

### DIFF
--- a/templates/module/links.task-entity-content.yml.twig
+++ b/templates/module/links.task-entity-content.yml.twig
@@ -5,6 +5,12 @@
   route_name: {{ entity_name }}.settings
   title: 'Settings'
   base_route: {{ entity_name }}.settings
+{% else %}
+entity.{{ entity_name }}_type.edit_form:
+  route_name: entity.{{ entity_name }}_type.edit_form
+  base_route: entity.{{ entity_name }}_type.edit_form
+  title: 'Edit'
+  weight: 0
 {% endif %}
 
 entity.{{ entity_name }}.canonical:


### PR DESCRIPTION
Field UI link tasks like 'manage fields' are using this link task as base route, so without this you can never switch back to bundle edit tab from other tabs
![entity-local-tasks](https://user-images.githubusercontent.com/42215392/70974715-b4e93b80-20a8-11ea-90d1-f37eee742021.png)
