### PR TITLE
fix sync directory path

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -107,7 +107,7 @@ class ExportCommand extends Command
 
         $fileSystem = new Filesystem();
         try {
-            $fileSystem->mkdir($drupal_root."/".$directory);
+            $fileSystem->mkdir($directory);
         } catch (IOExceptionInterface $e) {
             $this->getIo()->error(
                 sprintf(


### PR DESCRIPTION
This pull request is fixing the issue reported here

#4195 [config:export] Path is broken on windows #4195
https://www.drupal.org/project/drupal/issues/3103359
