### PR TITLE
Fix fatal when scaffolding a FieldWidget.

### DIFF
--- a/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
+++ b/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
@@ -12,6 +12,8 @@ namespace Drupal\{{ module }}\Plugin\Field\FieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Annotation\FieldWidget;
+use Drupal\Core\Annotation\Translation;
 {% endblock %}
 
 {% block class_declaration %}
@@ -20,7 +22,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @FieldWidget(
  *   id = "{{ plugin_id }}",
- *   module = "{{ module }}"
+ *   module = "{{ module }}",
  *   label = @Translation("{{ label }}"){% if field_type %},
  *   field_types = {
  *     "{{ field_type }}"


### PR DESCRIPTION
If you generate a new field widget through the scaffolding command `drupal gpfw`, you can't use your widget right away due to a fatal error caused by a missing comma and annotations inclusion.

The attached PR fixes it.