### PR TITLE
[config:export] fix path construction (#4245)

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
 use Symfony\Component\Filesystem\Filesystem;
 use Drupal\Core\Config\ConfigManager;
+use Webmozart\PathUtil\Path;
 
 class ExportCommand extends Command
 {
@@ -94,20 +95,22 @@ class ExportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $drupal_root = $this->drupalFinder->getComposerRoot();
-        $directory = $drupal_root.'/'.$input->getOption('directory');
+        $directory = $input->getOption('directory');
         $tar = $input->getOption('tar');
         $removeUuid = $input->getOption('remove-uuid');
         $removeHash = $input->getOption('remove-config-hash');
-        $drupal_root = $this->drupalFinder->getComposerRoot();
 
         if (!$directory) {
             $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
         }
+        if (!Path::isAbsolute($directory)) {
+            $drupal_root = $this->drupalFinder->getDrupalRoot();
+            $directory = $drupal_root . "/" . $directory;
+        }
 
         $fileSystem = new Filesystem();
         try {
-            $fileSystem->mkdir($drupal_root."/".$directory);
+            $fileSystem->mkdir($directory);
         } catch (IOExceptionInterface $e) {
             $this->getIo()->error(
                 sprintf(


### PR DESCRIPTION
- Use Drupal root, not Composer root.
- Avoid adding the root to an already absolute path.
- Avoid adding the root twice when creating the directory

Fixes #4245, fixes #4195, fixes #4198, fixes #4219 