### PR TITLE
Add Exception When Unable to load module from extensions. 

### DIFF
--- a/src/Generator/ComposerGenerator.php
+++ b/src/Generator/ComposerGenerator.php
@@ -39,13 +39,18 @@ class ComposerGenerator extends Generator
      */
     public function generate(array $parameters)
     {
-        $machineName = $parameters['machine_name'];
-        $this->renderFile(
-          'module/composer.json.twig',
-          $this->extensionManager->getModule($machineName)
-            ->getPath() . '/composer.json',
-          $parameters
-        );
+      $machineName = $parameters['machine_name'];
+      $module = $this->extensionManager->getModule($machineName);
+      if (!$module) {
+        throw new \Exception(
+          "Unable to load module: \"{$machineName}\" from extension manager. This may be an unresolved issue in the module generator. This will prevent the generator from creating the composer.json file for the module. Try calling the command without setting dependencies. See https://github.com/hechoendrupal/drupal-console/issues/4118");
+      }
+      $this->renderFile(
+        'module/composer.json.twig',
+        $this->extensionManager->getModule($machineName)
+          ->getPath() . '/composer.json',
+        $parameters
+      );
     }
 
 }

--- a/src/Generator/ComposerGenerator.php
+++ b/src/Generator/ComposerGenerator.php
@@ -47,8 +47,7 @@ class ComposerGenerator extends Generator
       }
       $this->renderFile(
         'module/composer.json.twig',
-        $this->extensionManager->getModule($machineName)
-          ->getPath() . '/composer.json',
+        $module->getPath() . '/composer.json',
         $parameters
       );
     }


### PR DESCRIPTION
Throws exception when unable to load module extension for module generator. Debugging/Addresses https://github.com/hechoendrupal/drupal-console/issues/4118

I'm not sure how you feel about calling out individual Issues in exception messages. But this seems like a highly specific problem anyway. 