### PR TITLE
Add missing comma to fix generation of field widget

### DIFF
--- a/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
+++ b/templates/module/src/Plugin/Field/FieldWidget/fieldwidget.php.twig
@@ -20,7 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @FieldWidget(
  *   id = "{{ plugin_id }}",
- *   module = "{{ module }}"
+ *   module = "{{ module }}",
  *   label = @Translation("{{ label }}"){% if field_type %},
  *   field_types = {
  *     "{{ field_type }}"


### PR DESCRIPTION
Before, this happens:

```console
$ drupal generate:plugin:fieldwidget

 // Welcome to the Drupal Field Widget Plugin generator
 Enter the module name [admin_toolbar]:
 > my_core

 Enter the plugin class name [ExampleFieldWidget]:
 > ContentModifiedWidget

 Enter the plugin label [Content modified widget]:
 >

 Enter the plugin id [content_modified_widget]:
 >

 Enter the field type the plugin can be used with:
  [0 ] boolean
  [1 ] datetime
  [2 ] email
  [3 ] link
  [4 ] metatag
  [5 ] timestamp
  [6 ] my_contributor
  [7 ] field_my_ims_image
  [8 ] my_related_links
  [9 ] list_float
  [10] list_integer
  [11] decimal
  [12] float
  [13] integer
  [14] block_field
  [15] field_ui:entity_reference:node
  [16] entity_reference
  [17] file
  [18] field_ui:entity_reference:taxonomy_term
  [19] field_ui:entity_reference:user
  [20] entity_reference_revisions
  [21] field_ui:entity_reference_revisions:paragraph
  [22] list_string
  [23] text
  [24] text_long
  [25] text_with_summary
  [26] string
  [27] string_long
 > 13

 Do you want proceed with the operation? (yes/no) [yes]:
 >


 // cache:rebuild

 Rebuilding cache(s), wait a moment please.


 [OK] Done clearing cache(s).


Generated or updated files
 Generation path: /var/www/html/docroot
 1 - modules/custom/my_core/src/Plugin/Field/FieldWidget/ContentModifiedWidget.php
 2 - modules/custom/my_core/my_core.schema.yml


 Generated lines: 95




 [ERROR] <em class="placeholder">Warning</em>: Error while sending QUERY packet. PID=273 in <em
         class="placeholder">Drupal\Core\Database\Statement-&gt;execute()</em> (line <em class="placeholder">59</em>
         of <em class="placeholder">core/lib/Drupal/Core/Database/Statement.php</em>). <pre
         class="backtrace">Drupal\Core\Database\Statement-&gt;execute(Array, Array) (Line: 640)
         Drupal\Core\Database\Connection-&gt;query(&#039;DELETE FROM {key_value}
         WHERE (name IN (:db_condition_placeholder_0)) AND (collection = :db_condition_placeholder_1)&#039;, Array,
         Array) (Line: 357)
         Drupal\Core\Database\Driver\mysql\Connection-&gt;query(&#039;DELETE FROM {key_value}
         WHERE (name IN (:db_condition_placeholder_0)) AND (collection = :db_condition_placeholder_1)&#039;, Array,
         Array) (Line: 55)
         Drupal\Core\Database\Query\Delete-&gt;execute() (Line: 155)
         Drupal\Core\KeyValueStore\DatabaseStorage-&gt;deleteMultiple(Array) (Line: 111)
         Drupal\Core\State\State-&gt;deleteMultiple(Array) (Line: 101)
         Drupal\Core\State\State-&gt;delete(&#039;system.module.files&#039;) (Line: 171)
         Drupal\Core\Extension\ExtensionList-&gt;reset() (Line: 1023)
         system_rebuild_module_data() (Line: 226)
         Drupal\Console\Extension\Manager-&gt;discoverExtensions(&#039;module&#039;) (Line: 148)
         Drupal\Console\Extension\Manager-&gt;discoverExtension(&#039;module&#039;) (Line: 115)
         Drupal\Console\Extension\Manager-&gt;discoverModules() (Line: 308)
         Drupal\Console\Utils\Validator-&gt;getMissingModules(Array) (Line: 88)
         Drupal\Console\Command\Generate\PluginFieldWidgetCommand-&gt;validateModule(&#039;my_core&#039;) (Line: 140)
         Drupal\Console\Command\Generate\PluginFieldWidgetCommand-&gt;execute(Object, Object) (Line: 255)
         Symfony\Component\Console\Command\Command-&gt;run(Object, Object) (Line: 1005)
         Symfony\Component\Console\Application-&gt;doRunCommand(Object, Object, Object) (Line: 255)
         Symfony\Component\Console\Application-&gt;doRun(Object, Object) (Line: 187)
         Drupal\Console\Core\Application-&gt;doRun(Object, Object) (Line: 64)
         Drupal\Console\Application-&gt;doRun(Object, Object) (Line: 148)
         Symfony\Component\Console\Application-&gt;run() (Line: 89)
         require(&#039;/var/www/html/vendor/drupal/console/bin/drupal.php&#039;) (Line: 4)
         </pre>

```

With an error like this at `/admin/structure/types/manage/article/form-display`:

```
The website encountered an unexpected error. Please try again later.

Doctrine\Common\Annotations\AnnotationException: [Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_PARENTHESIS, got 'label' at position 81 in class Drupal\my_core\Plugin\Field\FieldWidget\ContentModifiedWidget. in Doctrine\Common\Annotations\AnnotationException::syntaxError() (line 42 of /var/www/html/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php).
Drupal\Component\Annotation\Doctrine\DocParser->syntaxError('Doctrine\Common\Annotations\DocLexer::T_CLOSE_PARENTHESIS') (Line: 376)
Drupal\Component\Annotation\Doctrine\DocParser->match(103) (Line: 838)
Drupal\Component\Annotation\Doctrine\DocParser->MethodCall() (Line: 746)
Drupal\Component\Annotation\Doctrine\DocParser->Annotation() (Line: 640)
Drupal\Component\Annotation\Doctrine\DocParser->Annotations() (Line: 338)
Drupal\Component\Annotation\Doctrine\DocParser->parse('/**
 * Plugin implementation of the 'content_modified_widget' widget.
 *
 * @FieldWidget(
 *   id = "content_modified_widget",
 *   module = "my_core"
 *   label = @Translation("Content modified widget"),
 *   field_types = {
 *     "integer"
 *   }
 * )
 */', 'class Drupal\my_core\Plugin\Field\FieldWidget\ContentModifiedWidget') (Line: 101)
Drupal\Component\Annotation\Doctrine\SimpleAnnotationReader->getClassAnnotations(Object) (Line: 125)
Drupal\Component\Annotation\Doctrine\SimpleAnnotationReader->getClassAnnotation(Object, 'Drupal\Core\Field\Annotation\FieldWidget') (Line: 145)
Drupal\Component\Annotation\Plugin\Discovery\AnnotatedClassDiscovery->getDefinitions() (Line: 86)
Drupal\Component\Plugin\Discovery\DerivativeDiscoveryDecorator->getDefinitions() (Line: 284)
Drupal\Core\Plugin\DefaultPluginManager->findDefinitions() (Line: 175)
Drupal\Core\Plugin\DefaultPluginManager->getDefinitions() (Line: 22)
Drupal\Core\Plugin\DefaultPluginManager->getDefinition('string_textarea', ) (Line: 202)
Drupal\Core\Field\WidgetPluginManager->getDefaultSettings('string_textarea') (Line: 151)
Drupal\Core\Field\WidgetPluginManager->prepareConfiguration('string_long', Array) (Line: 382)
Drupal\Core\Entity\EntityDisplayBase->setComponent('revision_log', Array) (Line: 197)
Drupal\Core\Entity\EntityDisplayBase->init() (Line: 143)
Drupal\Core\Entity\EntityDisplayBase->__construct(Array, 'entity_form_display') (Line: 136)
Drupal\Core\Entity\Entity\EntityFormDisplay->__construct(Array, 'entity_form_display') (Line: 387)
Drupal\Core\Entity\EntityStorageBase->mapFromStorageRecords(Array, Array) (Line: 193)
Drupal\Core\Config\Entity\ConfigEntityStorage->doLoadMultiple(Array) (Line: 300)
Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array) (Line: 250)
Drupal\Core\Entity\EntityStorageBase->load('node.article.default') (Line: 280)
Drupal\Core\Entity\EntityDisplayRepository->getFormDisplay('node', 'article', 'default') (Line: 58)
Drupal\field_ui\Form\EntityFormDisplayEditForm->getEntityDisplay('node', 'article', 'default') (Line: 101)
Drupal\field_ui\Form\EntityDisplayFormBase->getEntityFromRouteMatch(Object, 'entity_form_display') (Line: 86)
Drupal\Core\Entity\HtmlEntityFormController->getFormObject(Object, 'entity_form_display.edit.default') (Line: 76)
Drupal\Core\Controller\FormController->getContentResult(Object, Object)
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 573)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 151)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 708)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```


This fixes the generated `docroot/modules/custom/my_core/src/Plugin/Field/FieldWidget/ContentModifiedWidget.php`:

```diff
 /**
  * Plugin implementation of the 'content_modified_widget' widget.
  *
  * @FieldWidget(
  *   id = "content_modified_widget",
- *   module = "my_core"
+ *   module = "my_core",
  *   label = @Translation("Content modified widget"),
  *   field_types = {
  *     "integer"
  *   }
  * )
  */
```
