### PR TITLE
Drupal 9 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "docs": "https://docs.drupalconsole.com/"
     },
     "require": {
-        "php": "^5.5.9 || ^7.0",
+        "php": ">=7.0.8",
         "alchemy/zippy": "~0.4",
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
@@ -44,9 +44,9 @@
         "drupal/console-core": "1.9.4",
         "drupal/console-extend-plugin": "~0",
         "psy/psysh": "0.6.* || ~0.8",
-        "symfony/css-selector": "~2.8|~3.0",
-        "symfony/dom-crawler": "~2.8|~3.0",
-        "symfony/http-foundation": "~2.8|~3.0"
+        "symfony/css-selector": "~3.0|~4.0",
+        "symfony/dom-crawler": "~3.0|~4.0",
+        "symfony/http-foundation": "~3.0|~4.0"
     },
     "suggest": {
         "symfony/thanks": "Thank your favorite PHP projects on GitHub using the CLI",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "composer/installers": "~1.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
-        "drupal/console-core": "1.9.4",
+        "drupal/console-core": "1.9.5",
         "drupal/console-extend-plugin": "~0",
         "psy/psysh": "0.6.* || ~0.8",
         "symfony/css-selector": "~3.0|~4.0",

--- a/config/services/debug.yml
+++ b/config/services/debug.yml
@@ -23,7 +23,7 @@ services:
       - { name: drupal.command }
   console.user_debug:
     class: Drupal\Console\Command\Debug\UserCommand
-    arguments: ['@entity_type.manager','@entity.query', '@console.drupal_api']
+    arguments: ['@entity_type.manager', '@console.drupal_api']
     tags:
       - { name: drupal.command }
   console.views_debug:

--- a/config/services/rest.yml
+++ b/config/services/rest.yml
@@ -10,6 +10,5 @@ services:
       - '@entity_type.manager'
       - '@?plugin.manager.rest'
       - '@authentication_collector'
-      - '@entity.manager'
     tags:
       - { name: drupal.command }

--- a/config/services/site.yml
+++ b/config/services/site.yml
@@ -16,7 +16,7 @@ services:
       - { name: drupal.command }
   console.site_statistics:
     class: Drupal\Console\Command\Site\StatisticsCommand
-    arguments: ['@console.drupal_api', '@entity.query', '@console.extension_manager', '@module_handler']
+    arguments: ['@console.drupal_api', '@entity_type.manager', '@console.extension_manager', '@module_handler']
     tags:
       - { name: drupal.command }
   console.site_status:

--- a/config/services/user.yml
+++ b/config/services/user.yml
@@ -1,7 +1,7 @@
 services:
   console.user_delete:
     class: Drupal\Console\Command\User\DeleteCommand
-    arguments: ['@entity_type.manager','@entity.query', '@console.drupal_api']
+    arguments: ['@entity_type.manager', '@console.drupal_api']
     tags:
       - { name: drupal.command }
   console.user_login_clear_attempts:

--- a/config/services/views.yml
+++ b/config/services/views.yml
@@ -1,11 +1,11 @@
 services:
   console.views_disable:
     class: Drupal\Console\Command\Views\DisableCommand
-    arguments: ['@entity_type.manager', '@entity.query']
+    arguments: ['@entity_type.manager']
     tags:
       - { name: drupal.command }
   console.views_enable:
     class: Drupal\Console\Command\Views\EnableCommand
-    arguments: ['@entity_type.manager', '@entity.query']
+    arguments: ['@entity_type.manager']
     tags:
       - { name: drupal.command }

--- a/src/Application.php
+++ b/src/Application.php
@@ -25,7 +25,7 @@ class Application extends BaseApplication
     /**
      * @var string
      */
-    const VERSION = '1.9.4';
+    const VERSION = '1.9.5';
 
     public function __construct(ContainerInterface $container)
     {

--- a/src/Command/Debug/UserCommand.php
+++ b/src/Command/Debug/UserCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Console\Utils\DrupalApi;
 
 /**
@@ -28,11 +27,6 @@ class UserCommand extends Command
     protected $entityTypeManager;
 
     /**
-     * @var QueryFactory
-     */
-    protected $entityQuery;
-
-    /**
      * @var DrupalApi
      */
     protected $drupalApi;
@@ -41,16 +35,13 @@ class UserCommand extends Command
      * DebugCommand constructor.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
-     * @param QueryFactory               $entityQuery
      * @param DrupalApi                  $drupalApi
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        QueryFactory $entityQuery,
         DrupalApi $drupalApi
     ) {
         $this->entityTypeManager = $entityTypeManager;
-        $this->entityQuery = $entityQuery;
         $this->drupalApi = $drupalApi;
         parent::__construct();
     }
@@ -110,7 +101,7 @@ class UserCommand extends Command
         $userStorage = $this->entityTypeManager->getStorage('user');
         $systemRoles = $this->drupalApi->getRoles();
 
-        $query = $this->entityQuery->get('user');
+        $query = $this->entityTypeManager->getStorage('user')->getQuery();
         $query->condition('uid', 0, '>');
         $query->sort('uid');
 

--- a/src/Command/Rest/EnableCommand.php
+++ b/src/Command/Rest/EnableCommand.php
@@ -16,7 +16,6 @@ use Drupal\rest\RestResourceConfigInterface;
 use Drupal\Console\Command\Shared\RestTrait;
 use Drupal\rest\Plugin\Type\ResourcePluginManager;
 use Drupal\Core\Authentication\AuthenticationCollector;
-use Drupal\Core\Entity\EntityManager;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -45,31 +44,20 @@ class EnableCommand extends ContainerAwareCommand
     protected $authenticationCollector;
 
     /**
-     * The entity manager.
-     *
-     * @var EntityManager
-     */
-    protected $entityManager;
-
-    /**
      * EnableCommand constructor.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
      * @param ResourcePluginManager      $pluginManagerRest
      * @param AuthenticationCollector    $authenticationCollector
-     * @param EntityManager              $entity_manager
-     *   The entity manager.
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
         ResourcePluginManager $pluginManagerRest,
-        AuthenticationCollector $authenticationCollector,
-        EntityManager $entity_manager
+        AuthenticationCollector $authenticationCollector
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->pluginManagerRest = $pluginManagerRest;
         $this->authenticationCollector = $authenticationCollector;
-        $this->entityManager = $entity_manager;
         parent::__construct();
     }
 
@@ -146,9 +134,9 @@ class EnableCommand extends ContainerAwareCommand
         );
 
         $format_resource_id = str_replace(':', '.', $resource_id);
-        $config = $this->entityManager->getStorage('rest_resource_config')->load($format_resource_id);
+        $config = $this->entityTypeManager->getStorage('rest_resource_config')->load($format_resource_id);
         if (!$config) {
-            $config = $this->entityManager->getStorage('rest_resource_config')->create(
+            $config = $this->entityTypeManager->getStorage('rest_resource_config')->create(
                 [
                 'id' => $format_resource_id,
                 'granularity' => RestResourceConfigInterface::METHOD_GRANULARITY,

--- a/src/Command/Site/StatisticsCommand.php
+++ b/src/Command/Site/StatisticsCommand.php
@@ -10,10 +10,10 @@ namespace Drupal\Console\Command\Site;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Extension\Manager;
 use Drupal\Console\Utils\DrupalApi;
-use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
  * Class StatisticsCommand
@@ -28,11 +28,6 @@ class StatisticsCommand extends Command
     protected $drupalApi;
 
     /**
-     * @var QueryFactory
-     */
-    protected $entityQuery;
-
-    /**
      * @var Manager
      */
     protected $extensionManager;
@@ -43,21 +38,25 @@ class StatisticsCommand extends Command
     protected $moduleHandler;
 
     /**
+     * @var EntityTypeManagerInterface
+     */
+    protected $entityTypeManager;
+
+    /**
      * StatisticsCommand constructor.
      *
      * @param DrupalApi $drupalApi
-     * @param QueryFactory $entityQuery ;
      * @param Manager $extensionManager
      * @param ModuleHandlerInterface $moduleHandler
      */
     public function __construct(
         DrupalApi $drupalApi,
-        QueryFactory $entityQuery,
+        EntityTypeManagerInterface $entityTypeManager,
         Manager $extensionManager,
         ModuleHandlerInterface $moduleHandler
     ) {
         $this->drupalApi = $drupalApi;
-        $this->entityQuery = $entityQuery;
+        $this->entityTypeManager = $entityTypeManager;
         $this->extensionManager = $extensionManager;
         $this->moduleHandler = $moduleHandler;
         parent::__construct();
@@ -131,7 +130,7 @@ class StatisticsCommand extends Command
 
     private function getEntitiesCount($entity_type, $condition = [])
     {
-        $entityQuery = $this->entityQuery->get($entity_type)->count();
+        $entityQuery = $this->entityTypeManager->getStorage($entity_type)->getQuery()->count();
         if (!empty($condition)) {
             $entityQuery->condition($condition['name'], $condition['value'], $condition['condition']);
         }

--- a/src/Command/User/DeleteCommand.php
+++ b/src/Command/User/DeleteCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Console\Utils\DrupalApi;
 
 /**
@@ -22,11 +21,6 @@ use Drupal\Console\Utils\DrupalApi;
 class DeleteCommand extends UserBase
 {
     /**
-     * @var QueryFactory
-     */
-    protected $entityQuery;
-
-    /**
      * @var DrupalApi
      */
     protected $drupalApi;
@@ -35,15 +29,12 @@ class DeleteCommand extends UserBase
      * DeleteCommand constructor.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
-     * @param QueryFactory               $entityQuery
      * @param DrupalApi                  $drupalApi
      */
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        QueryFactory $entityQuery,
         DrupalApi $drupalApi
     ) {
-        $this->entityQuery = $entityQuery;
         $this->drupalApi = $drupalApi;
         parent::__construct($entityTypeManager);
     }
@@ -152,9 +143,8 @@ class DeleteCommand extends UserBase
         if ($roles) {
             $roles = is_array($roles)?$roles:[$roles];
 
-            $query = $this->entityQuery
-                ->get('user')
-                ->condition('roles', array_values($roles), 'IN')
+            $query = $this->entityTypeManager->getStorage('user')->getQuery();
+            $query->condition('roles', array_values($roles), 'IN')
                 ->condition('uid', 1, '>');
             $results = $query->execute();
 

--- a/src/Command/Views/DisableCommand.php
+++ b/src/Command/Views/DisableCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryFactory;
 
 /**
  * Class DisableCommand
@@ -27,22 +26,14 @@ class DisableCommand extends Command
     protected $entityTypeManager;
 
     /**
-     * @var QueryFactory
-     */
-    protected $entityQuery;
-
-    /**
      * DisableCommand constructor.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
-     * @param QueryFactory               $entityQuery
      */
     public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        QueryFactory $entityQuery
+        EntityTypeManagerInterface $entityTypeManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
-        $this->entityQuery = $entityQuery;
         parent::__construct();
     }
 
@@ -69,10 +60,9 @@ class DisableCommand extends Command
     {
         $viewId = $input->getArgument('view-id');
         if (!$viewId) {
-            $views = $this->entityQuery
-                ->get('view')
-                ->condition('status', 1)
-                ->execute();
+            $query = $this->entityTypeManager->getStorage('view')->getQuery();
+            $views = $query->condition('status', 1)->execute();
+
             $viewId = $this->getIo()->choiceNoList(
                 $this->trans('commands.debug.views.arguments.view-id'),
                 $views
@@ -87,12 +77,10 @@ class DisableCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $viewId = $input->getArgument('view-id');
-
         $view = $this->entityTypeManager->getStorage('view')->load($viewId);
 
         if (empty($view)) {
             $this->getIo()->error(sprintf($this->trans('commands.debug.views.messages.not-found'), $viewId));
-
             return 1;
         }
 

--- a/src/Command/Views/EnableCommand.php
+++ b/src/Command/Views/EnableCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryFactory;
 
 /**
  * Class EnableCommand
@@ -28,22 +27,14 @@ class EnableCommand extends Command
     protected $entityTypeManager;
 
     /**
-     * @var QueryFactory
-     */
-    protected $entityQuery;
-
-    /**
      * EnableCommand constructor.
      *
      * @param EntityTypeManagerInterface $entityTypeManager
-     * @param QueryFactory               $entityQuery
      */
     public function __construct(
-        EntityTypeManagerInterface $entityTypeManager,
-        QueryFactory $entityQuery
+        EntityTypeManagerInterface $entityTypeManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
-        $this->entityQuery = $entityQuery;
         parent::__construct();
     }
 
@@ -70,10 +61,9 @@ class EnableCommand extends Command
     {
         $viewId = $input->getArgument('view-id');
         if (!$viewId) {
-            $views = $this->entityQuery
-                ->get('view')
-                ->condition('status', 0)
-                ->execute();
+            $query = $this->entityTypeManager->getStorage('view')->getQuery();
+            $views = $query->condition('status', 0)->execute();
+
             $viewId = $this->getIo()->choiceNoList(
                 $this->trans('commands.debug.views.arguments.view-id'),
                 $views
@@ -88,7 +78,6 @@ class EnableCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $viewId = $input->getArgument('view-id');
-
         $view = $this->entityTypeManager->getStorage('view')->load($viewId);
 
         if (empty($view)) {

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -5,6 +5,7 @@ namespace Drupal\Console\Extension;
 use Drupal\Console\Utils\Site;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use  Drupal\Core\Extension\ModuleExtensionList;
 
 /**
  * Class ExtensionManager
@@ -44,20 +45,28 @@ class Manager
     private $extension = null;
 
     /**
+     * @var Drupal\Core\Extension\ModuleExtensionList
+     */
+    private $extensionList;
+
+    /**
      * ExtensionManager constructor.
      *
      * @param Site   $site
      * @param Client $httpClient
      * @param string $appRoot
+     * @param ModuleExtensionList $extensionList
      */
     public function __construct(
         Site $site,
         Client $httpClient,
-        $appRoot
+        $appRoot,
+        ModuleExtensionList $extensionList
     ) {
         $this->site = $site;
         $this->httpClient = $httpClient;
         $this->appRoot = $appRoot;
+        $this->extensionList = $extensionList;
         $this->initialize();
     }
 
@@ -223,7 +232,7 @@ class Manager
     {
         if ($type === 'module') {
             $this->site->loadLegacyFile('/core/modules/system/system.module');
-            system_rebuild_module_data();
+            $this->extensionList->reset()->getList();
         }
 
         if ($type === 'theme') {

--- a/uninstall.services.yml
+++ b/uninstall.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@app.root', '@console.configuration_manager']
   console.extension_manager:
     class: Drupal\Console\Extension\Manager
-    arguments: ['@console.site', '@http_client', '@app.root']
+    arguments: ['@console.site', '@http_client', '@app.root', '@extension.list.module']
   # Commands
   console.server:
     class: Drupal\Console\Command\ServerCommand


### PR DESCRIPTION
## Drupal 9 Support

I removed the deprecated services and updated the symfony dependencies in order to be compatibles with Drupal 9

Major changes:
Remove support for PHP 5
Support for twig 2
Support for Symfony 4.4