### PR TITLE
[generate:command] Regression with the Annotation stops custom translations from working

### DIFF
--- a/templates/module/src/Command/command.php.twig
+++ b/templates/module/src/Command/command.php.twig
@@ -22,7 +22,7 @@ use Drupal\Console\Core\Command\Command;
 /**
  * Class {{ class_name }}.
  *
- * Drupal\Console\Annotations\DrupalCommand (
+ * @Drupal\Console\Annotations\DrupalCommand (
  *     extension="{{extension}}",
  *     extensionType="{{ extension_type }}"
  * )


### PR DESCRIPTION
The #4074 PR introduced a regression with the annotations.

The `DrupalCommand` annotation was missing the `@` annotation token prefix, which stops translations from being detected for generated commands as it fails validation and marked as an invalid command in the following:
https://github.com/hechoendrupal/drupal-console/blob/e582d885aadcf57694043dc8b02acd151f8fdf98/src/Application.php#L123-L129