### PR TITLE
Previously included classloader fails loading of Drupal kernel

### DIFF
--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -33,7 +33,7 @@ foreach ($autoloaders as $file) {
 }
 
 if (isset($autoloader)) {
-    $autoload = include_once $autoloader;
+    $autoload = include $autoloader;
 } else {
     echo ' You must set up the project dependencies using `composer install`' . PHP_EOL;
     exit(1);


### PR DESCRIPTION
It is safe to change the expression because the autoloader script will return the already initiated instance.