### PR TITLE
Fix the entity revision revert and delete buttons on the revisions tab

### DIFF
--- a/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
@@ -88,7 +88,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ${{ entity_name }}_revision = NULL) {
-    $this->revision = $this->{{ entity_class }}Storage->loadRevision(${{ entity_name }}_revision);
+    $this->revision = $this->{{ entity_class[:1]|lower ~ entity_class[1:] }}Storage->loadRevision(${{ entity_name }}_revision);
     $form = parent::buildForm($form, $form_state);
 
     return $form;
@@ -98,7 +98,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->{{ entity_class }}Storage->deleteRevision($this->revision->getRevisionId());
+    $this->{{ entity_class[:1]|lower ~ entity_class[1:] }}Storage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('{{ label }}: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
     $this->messenger()->addMessage(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
@@ -106,7 +106,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
       'entity.{{ entity_name }}.canonical',
        ['{{ entity_name }}' => $this->revision->id()]
     );
-    if ($this->connection->query('SELECT COUNT(DISTINCT vid) FROM {{ '{'~entity_name~'_field_revision}' }} WHERE id = :id', [':id' => $this->revision->id()])->fetchField() > 1) {
+    if ($this->connection->query('SELECT COUNT(DISTINCT vid) FROM {{ '{'~entity_name }}{% if is_translatable %}_field{% endif %}{{ '_revision}' }} WHERE id = :id', [':id' => $this->revision->id()])->fetchField() > 1) {
       $form_state->setRedirect(
         'entity.{{ entity_name }}.version_history',
          ['{{ entity_name }}' => $this->revision->id()]

--- a/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
@@ -96,7 +96,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ${{ entity_name }}_revision = NULL) {
-    $this->revision = $this->{{ entity_class }}Storage->loadRevision(${{ entity_name }}_revision);
+    $this->revision = $this->{{ entity_class[:1]|lower ~ entity_class[1:] }}Storage->loadRevision(${{ entity_name }}_revision);
     $form = parent::buildForm($form, $form_state);
 
     return $form;


### PR DESCRIPTION
### Problem/Motivation
When creating an entity using Drupal 8.9.13 and Console 1.9.7 and the command generate:entity:content the revert and delete links on the entity's revisions tab fail with an error

`Error: Call to a member function loadRevision() on null in Drupal\my_module\Form\ExampleRevisionRevertForm->buildForm() (line 90 of /web/public/modules/custom/my_module/src/Form/ExampleRevisionRevertForm.php) `

and

`Error: Call to a member function loadRevision() on null in Drupal\my_module\Form\ExampleRevisionDeleteForm->buildForm() (line 90 of /web/public/modules/custom/my_module/src/Form/ExampleRevisionDeleteForm.php) `

These two errors are caused by $this->{{ entity_class }}Storage->loadRevision as the entity class has a capital letter at the start whereas other references to it use a lower case first letter.
 
There is a further error on the delete confirmation page when the created entity is not translatable.

This is caused by a hard coded reference to the {'~entity_name~'_field_revision} table which doesn't exist for entities that aren't translatable.

### How to reproduce
Using Drupal 8.9.13 and Console 1.9.7 create an entity using 'generate:entity:content'.
Add a piece of content and save
Revise the piece of entity and save
Click the Revisions tab and try and revert or delete the old revision.

### Solution
This patch alters the relevant templates and should fix all of these problems.
