### PR TITLE
Fix errors from invalid YAML

### DIFF
--- a/config/services/generate.yml
+++ b/config/services/generate.yml
@@ -23,7 +23,7 @@ services:
     class: Drupal\Console\Command\Generate\AjaxCommand
     arguments: ['@console.extension_manager', '@console.ajax_command_generator', '@console.validator', '@console.chain_queue']
     tags:
-       - { name: drupal.command }      
+       - { name: drupal.command }
   console.generate_breakpoint:
     class: Drupal\Console\Command\Generate\BreakPointCommand
     arguments: ['@console.breakpoint_generator', '@app.root', '@theme_handler', '@console.validator', '@console.string_converter']

--- a/config/services/generator.yml
+++ b/config/services/generator.yml
@@ -26,7 +26,7 @@ services:
     class: Drupal\Console\Generator\AjaxCommandGenerator
     arguments: ['@console.extension_manager']
     tags:
-      - { name: drupal.generator }    
+      - { name: drupal.generator }
   console.breakpoint_generator:
     class: Drupal\Console\Generator\BreakPointGenerator
     arguments: ['@console.extension_manager']


### PR DESCRIPTION
On a new drupal install, I was getting errors for any console command I tried to run.
```
[ERROR] A "tags" entry must be an array for service "console.generate_ajax" in
         /app/vendor/drupal/console//config/services/generate.yml. Check your YAML syntax.
```
```
[ERROR] A "tags" entry must be an array for service "console.ajax_command_generator" in
         /app/vendor/drupal/console//config/services/generator.yml. Check your YAML syntax.
```

The culprit turned out to be trailing spaces in the Ajax generate commands. Not sure why this would cause an error, though I guess this is technically invalid YAML. In any case, removing the trailing whitespace resolved the issue.