### PR TITLE
[debug:database:log] Respect limit and offset command options

### DIFF
--- a/src/Command/Database/DatabaseLogBase.php
+++ b/src/Command/Database/DatabaseLogBase.php
@@ -182,18 +182,6 @@ abstract class DatabaseLogBase extends Command
 
         $query->orderBy('wid', 'ASC');
 
-        if ($this->limit) {
-            $range = $this->limit;
-        }
-
-        if ($this->limit && $offset === null) {
-            if ($this->offset) {
-                $offset = $this->offset;
-            } else {
-                $offset = 0;
-            }
-        }
-
         if ($offset !== null) {
             $query->range($offset, $range);
         }

--- a/src/Command/Database/DatabaseLogBase.php
+++ b/src/Command/Database/DatabaseLogBase.php
@@ -182,7 +182,19 @@ abstract class DatabaseLogBase extends Command
 
         $query->orderBy('wid', 'ASC');
 
-        if ($offset) {
+        if ($this->limit) {
+            $range = $this->limit;
+        }
+
+        if ($this->limit && $offset === null) {
+            if ($this->offset) {
+                $offset = $this->offset;
+            } else {
+                $offset = 0;
+            }
+        }
+
+        if ($offset !== null) {
             $query->range($offset, $range);
         }
 

--- a/src/Command/Debug/DatabaseLogCommand.php
+++ b/src/Command/Debug/DatabaseLogCommand.php
@@ -149,7 +149,15 @@ class DatabaseLogCommand extends DatabaseLogBase
    */
     private function getAllEvents()
     {
-        $query = $this->makeQuery();
+        if (!$this->offset) {
+            $this->offset = 0;
+        }
+
+        if (!$this->limit) {
+            $this->limit = 1000;
+        }
+
+        $query = $this->makeQuery($this->offset, $this->limit);
 
         $result = $query->execute();
 


### PR DESCRIPTION
Hi 😸

I've added the handling of **limit** and **offset** options of the **debug:database:log** command.

```
Drupal                         8.9.15 
Drupal Console                 1.9.7

drupal/console                           1.9.7
drupal/console-core                      1.9.7
drupal/console-en                        v1.9.7
drupal/console-extend-plugin             0.9.5
```

Have a nice day