### PR TITLE
fix optional argument before mandatory argument php8 warning

### DIFF
--- a/src/Bootstrap/DrupalServiceModifier.php
+++ b/src/Bootstrap/DrupalServiceModifier.php
@@ -39,7 +39,7 @@ class DrupalServiceModifier implements ServiceModifierInterface
      * @param ConfigurationInterface $configuration
      */
     public function __construct(
-        $root = null,
+        $root,
         $serviceTag,
         $generatorTag,
         $configuration


### PR DESCRIPTION
PHP8 outputs a notice for methods that define optional arguments before required arguments (https://php.watch/versions/8.0/deprecate-required-param-after-optional). Since the DrupalServiceModifier constructor in effect cannot be called without also providing the first argument (even if it's null), it should be safe to just remove the default value assignment. 

Fixes #4310 