### PR TITLE
[update:*] Remove deprecated update_fix_compatibility() call, removed in Drupal 9

### DIFF
--- a/src/Command/Debug/UpdateCommand.php
+++ b/src/Command/Debug/UpdateCommand.php
@@ -63,7 +63,6 @@ class UpdateCommand extends Command
         $this->site->loadLegacyFile('/core/includes/install.inc');
 
         drupal_load_updates();
-        update_fix_compatibility();
 
         $requirements = update_check_requirements();
         $severity = drupal_requirements_severity($requirements);

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -127,7 +127,6 @@ class ExecuteCommand extends Command
         $this->site->loadLegacyFile('/core/includes/update.inc');
 
         drupal_load_updates();
-        update_fix_compatibility();
 
         $start = $this->getUpdates($this->module!=='all'?$this->module:null);
         $updates = update_resolve_dependencies($start);


### PR DESCRIPTION
Removes calls to update_fix_compatibility(), as it was deprecated in Drupal 8 and removed in Drupal 9 with no replacement (see https://www.drupal.org/node/3026100).

Fixes #4302 