### PR TITLE
Avoid removed 'Unicode::strtolower()'

### DIFF
--- a/src/Utils/Create/VocabularyData.php
+++ b/src/Utils/Create/VocabularyData.php
@@ -7,7 +7,6 @@
 
 namespace Drupal\Console\Utils\Create;
 
-use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
@@ -40,7 +39,7 @@ class VocabularyData extends Base
                     [
                         'name' => $this->getRandom()->sentences(mt_rand(1, $nameWords), true),
                         'description' => $this->getRandom()->sentences(mt_rand(1, $nameWords)),
-                        'vid' => Unicode::strtolower($this->getRandom()->name()),
+                        'vid' => mb_strtolower($this->getRandom()->name()),
                         'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
                         'weight' => mt_rand(0, 10),
                     ]


### PR DESCRIPTION
Unicode::strtolower() was deprecated in D8 and isn't available in D9.
https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21Unicode.php/function/Unicode%3A%3Astrtolower/8.6.x
https://www.drupal.org/node/2850048

https://github.com/hechoendrupal/drupal-console/issues/4314