### PR TITLE
config_get_config_directory : Deprecated in drupal:8.8.0 and is remov…

### DIFF
--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -11,6 +11,7 @@ use Drupal\Core\Archiver\ArchiveTar;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Site\Settings;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -83,7 +84,7 @@ class ExportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.export.questions.directory'),
-                config_get_config_directory(CONFIG_SYNC_DIRECTORY)
+                Settings::get('config_sync_directory')
             );
             $input->setOption('directory', $directory);
         }
@@ -102,7 +103,7 @@ class ExportCommand extends Command
         $drupal_root = $this->drupalFinder->getComposerRoot();
 
         if (!$directory) {
-            $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+            $directory = Settings::get('config_sync_directory');
         }
 
         $fileSystem = new Filesystem();

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -16,6 +16,7 @@ use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Utils\Validator;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Config\CachedStorage;
+use Drupal\Core\Site\Settings;
 use Drupal\Console\Command\Shared\ExportTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
 use Drupal\Console\Extension\Manager;
@@ -304,7 +305,7 @@ class ExportSingleCommand extends Command
                 return 0;
             }
 
-            $directory = $directory_copy = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+            $directory = $directory_copy = Settings::get('config_sync_directory');
             if (!is_dir($directory)) {
                 if ($value) {
                     $directory = $directory_copy .'/' . str_replace('.', '/', $value);

--- a/src/Command/Config/ImportCommand.php
+++ b/src/Command/Config/ImportCommand.php
@@ -16,6 +16,7 @@ use Drupal\Core\Config\ConfigImporterException;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Config\StorageComparerInterface;
+use Drupal\Core\Site\Settings;
 
 class ImportCommand extends Command
 {
@@ -87,7 +88,7 @@ class ImportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.import.questions.directory'),
-                config_get_config_directory(CONFIG_SYNC_DIRECTORY)
+                Settings::get('config_sync_directory')
         );
             $input->setOption('directory', $directory);
         }


### PR DESCRIPTION
…ed from drupal:9.0.0. Use \Drupal\Core\Site\Settings::get('config_sync_directory') instead.