### PR TITLE
[console] Replace removed deprecated functions with Drupal 9 equivalents

### DIFF
--- a/src/Command/Config/DiffCommand.php
+++ b/src/Command/Config/DiffCommand.php
@@ -90,7 +90,7 @@ class DiffCommand extends Command
             $directory = $this->getIo()->choice(
                 $this->trans('commands.config.diff.questions.directories'),
                 $config_directories,
-                CONFIG_SYNC_DIRECTORY
+                \Drupal\Core\Site\Settings::get('config_sync_directory')
             );
 
             $input->setArgument('directory', $config_directories[$directory]);
@@ -103,7 +103,7 @@ class DiffCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         global $config_directories;
-        $directory = $input->getArgument('directory') ?: CONFIG_SYNC_DIRECTORY;
+        $directory = $input->getArgument('directory') ?: \Drupal\Core\Site\Settings::get('config_sync_directory');
         if (array_key_exists($directory, $config_directories)) {
             $directory = $config_directories[$directory];
         }

--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -83,7 +83,7 @@ class ExportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.export.questions.directory'),
-                config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'))
+                \Drupal\Core\Site\Settings::get('config_sync_directory')
             );
             $input->setOption('directory', $directory);
         }
@@ -102,7 +102,7 @@ class ExportCommand extends Command
         $drupal_root = $this->drupalFinder->getComposerRoot();
 
         if (!$directory) {
-            $directory = config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'));
+            $directory = \Drupal\Core\Site\Settings::get('config_sync_directory') ;
         }
 
         $fileSystem = new Filesystem();

--- a/src/Command/Config/ExportCommand.php
+++ b/src/Command/Config/ExportCommand.php
@@ -83,7 +83,7 @@ class ExportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.export.questions.directory'),
-                config_get_config_directory(CONFIG_SYNC_DIRECTORY)
+                config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'))
             );
             $input->setOption('directory', $directory);
         }
@@ -102,7 +102,7 @@ class ExportCommand extends Command
         $drupal_root = $this->drupalFinder->getComposerRoot();
 
         if (!$directory) {
-            $directory = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+            $directory = config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'));
         }
 
         $fileSystem = new Filesystem();

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -304,7 +304,7 @@ class ExportSingleCommand extends Command
                 return 0;
             }
 
-            $directory = $directory_copy = config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'));
+            $directory = $directory_copy = \Drupal\Core\Site\Settings::get('config_sync_directory') ;
             if (!is_dir($directory)) {
                 if ($value) {
                     $directory = $directory_copy .'/' . str_replace('.', '/', $value);

--- a/src/Command/Config/ExportSingleCommand.php
+++ b/src/Command/Config/ExportSingleCommand.php
@@ -304,7 +304,7 @@ class ExportSingleCommand extends Command
                 return 0;
             }
 
-            $directory = $directory_copy = config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+            $directory = $directory_copy = config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'));
             if (!is_dir($directory)) {
                 if ($value) {
                     $directory = $directory_copy .'/' . str_replace('.', '/', $value);

--- a/src/Command/Config/ImportCommand.php
+++ b/src/Command/Config/ImportCommand.php
@@ -87,7 +87,7 @@ class ImportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.import.questions.directory'),
-                config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'))
+                \Drupal\Core\Site\Settings::get('config_sync_directory')
         );
             $input->setOption('directory', $directory);
         }

--- a/src/Command/Config/ImportCommand.php
+++ b/src/Command/Config/ImportCommand.php
@@ -87,7 +87,7 @@ class ImportCommand extends Command
         if (!$input->getOption('directory')) {
             $directory = $this->getIo()->ask(
                 $this->trans('commands.config.import.questions.directory'),
-                config_get_config_directory(CONFIG_SYNC_DIRECTORY)
+                config_get_config_directory(\Drupal\Core\Site\Settings::get('config_sync_directory'))
         );
             $input->setOption('directory', $directory);
         }

--- a/src/Command/Cron/ExecuteCommand.php
+++ b/src/Command/Cron/ExecuteCommand.php
@@ -108,7 +108,7 @@ class ExecuteCommand extends Command
             }
         }
 
-        $this->state->set('system.cron_last', REQUEST_TIME);
+        $this->state->set('system.cron_last', \Drupal::time()->getRequestTime());
         $this->lock->release('cron');
 
         $this->getIo()->success($this->trans('commands.cron.execute.messages.success'));

--- a/src/Command/Debug/ModuleCommand.php
+++ b/src/Command/Debug/ModuleCommand.php
@@ -117,7 +117,7 @@ class ModuleCommand extends Command
     private function getModules($status, $type, $modules) {
 
         $result = [];
-        $modulesData = system_rebuild_module_data();
+        $modulesData = \Drupal::service('extension.list.module')->reset()->getList();
 
         if(!$modules) {
             $modules = array_keys($modulesData) ;

--- a/src/Command/Debug/RestCommand.php
+++ b/src/Command/Debug/RestCommand.php
@@ -89,7 +89,7 @@ class RestCommand extends Command
     {
         $config = $this->getRestDrupalConfig();
 
-        $plugin = $this->pluginManagerRest->getInstance(['id' => $resource_id]);
+        $plugin = $this->pluginManagerRest->createInstance($resource_id);
 
         if (empty($plugin)) {
             $this->getIo()->error(

--- a/src/Command/Debug/TestCommand.php
+++ b/src/Command/Debug/TestCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Annotations\DrupalCommand;
-use Drupal\simpletest\TestDiscovery;
+use Drupal\Core\Test\TestDiscovery;
 
 /**
  * @DrupalCommand(

--- a/src/Command/Debug/UpdateCommand.php
+++ b/src/Command/Debug/UpdateCommand.php
@@ -63,7 +63,6 @@ class UpdateCommand extends Command
         $this->site->loadLegacyFile('/core/includes/install.inc');
 
         drupal_load_updates();
-        update_fix_compatibility();
 
         $requirements = update_check_requirements();
         $severity = drupal_requirements_severity($requirements);

--- a/src/Command/DotenvInitCommand.php
+++ b/src/Command/DotenvInitCommand.php
@@ -125,7 +125,7 @@ class DotenvInitCommand extends GenerateCommand
         include_once $this->drupalFinder->getDrupalRoot() . '/core/includes/install.inc';
 
         $settings['config_directories'] = [
-            CONFIG_SYNC_DIRECTORY => (object) [
+            \Drupal\Core\Site\Settings::get('config_sync_directory') => (object) [
                 'value' => Path::makeRelative(
                     $this->drupalFinder->getComposerRoot() . '/config/sync',
                     $this->drupalFinder->getDrupalRoot()

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -175,7 +175,7 @@ class UninstallCommand extends ContainerAwareCommand
                 // to core yet so we need to check if it exists.
                 $profiles = \Drupal::service('profile_handler')->getProfileInheritance();
             } else {
-                $profiles[drupal_get_profile()] = [];
+                $profiles[\Drupal::installProfile()] = [];
             }
 
             $dependencies = [];

--- a/src/Command/Module/UninstallCommand.php
+++ b/src/Command/Module/UninstallCommand.php
@@ -124,7 +124,7 @@ class UninstallCommand extends ContainerAwareCommand
         $coreExtension = $this->configFactory->getEditable('core.extension');
 
         // Get info about modules available
-        $moduleData = system_rebuild_module_data();
+        $moduleData = \Drupal::service('extension.list.module')->reset()->getList();
         $moduleList = array_combine($module, $module);
 
         if ($composer) {

--- a/src/Command/Rest/EnableCommand.php
+++ b/src/Command/Rest/EnableCommand.php
@@ -96,7 +96,7 @@ class EnableCommand extends ContainerAwareCommand
         $input->setArgument('resource-id', $resource_id);
 
         // Calculate states available by resource and generate the question.
-        $plugin = $this->pluginManagerRest->getInstance(['id' => $resource_id]);
+        $plugin = $this->pluginManagerRest->createInstance($resource_id);
 
         $methods = $plugin->availableMethods();
         $method = $this->getIo()->choice(

--- a/src/Command/Shared/LocaleTrait.php
+++ b/src/Command/Shared/LocaleTrait.php
@@ -68,8 +68,8 @@ trait LocaleTrait
                 if ($project_info->type == LOCALE_TRANSLATION_LOCAL || $project_info->type == LOCALE_TRANSLATION_REMOTE) {
                     $local = isset($project_info->files[LOCALE_TRANSLATION_LOCAL]) ? $project_info->files[LOCALE_TRANSLATION_LOCAL] : null;
                     $remote = isset($project_info->files[LOCALE_TRANSLATION_REMOTE]) ? $project_info->files[LOCALE_TRANSLATION_REMOTE] : null;
-                    $local_age = $local->timestamp? format_date($local->timestamp, 'html_date'): '';
-                    $remote_age = $remote->timestamp? format_date($remote->timestamp, 'html_date'): '';
+                    $local_age = $local->timestamp? \Drupal::service('date.formatter')->format($local->timestamp, 'html_date'): '';
+                    $remote_age = $remote->timestamp? \Drupal::service('date.formatter')->format($remote->timestamp, 'html_date'): '';
 
                     if ($local_age >= $remote_age) {
                         $info = $this->trans('commands.locale.translation.status.messages.translation-project-updated');

--- a/src/Command/Shared/ProjectDownloadTrait.php
+++ b/src/Command/Shared/ProjectDownloadTrait.php
@@ -128,7 +128,7 @@ trait ProjectDownloadTrait
 
         return $this->downloadModules($dependencies, $latest, $path, $resultList);
     }
-    
+
     private function downloadThemes($themes, $latest, $path = null, $resultList = [])
     {
         if (!$resultList) {
@@ -164,7 +164,7 @@ trait ProjectDownloadTrait
         $this->themeHandler->install($themes);
 
         $unInstalledThemes = $this->validator->getUninstalledThemes($themes);
-        
+
         if (!$unInstalledThemes) {
             return 0;
         }else{
@@ -175,7 +175,7 @@ trait ProjectDownloadTrait
     protected function calculateDependencies($modules)
     {
         $this->site->loadLegacyFile('/core/modules/system/system.module');
-        $moduleList = system_rebuild_module_data();
+        $moduleList = \Drupal::service('extension.list.module')->reset()->getList();
 
         $dependencies = [];
 

--- a/src/Command/Test/RunCommand.php
+++ b/src/Command/Test/RunCommand.php
@@ -15,7 +15,7 @@ use Drupal\Component\Utility\Timer;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\simpletest\TestDiscovery;
+use Drupal\Core\Test\TestDiscovery;
 use Drupal\Core\Datetime\DateFormatter;
 
 /**

--- a/src/Command/Test/RunCommand.php
+++ b/src/Command/Test/RunCommand.php
@@ -117,7 +117,7 @@ class RunCommand extends Command
         $this->setEnvironment($url);
 
         // Create simpletest test id
-        $testId = db_insert('simpletest_test_id')
+        $testId =  Database::getConnection()->insert('simpletest_test_id')
           ->useDefaults(['test_id'])
           ->execute();
 

--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -127,7 +127,6 @@ class ExecuteCommand extends Command
         $this->site->loadLegacyFile('/core/includes/update.inc');
 
         drupal_load_updates();
-        update_fix_compatibility();
 
         $start = $this->getUpdates($this->module!=='all'?$this->module:null);
         $updates = update_resolve_dependencies($start);

--- a/src/Command/User/CreateCommand.php
+++ b/src/Command/User/CreateCommand.php
@@ -235,7 +235,7 @@ class CreateCommand extends Command
                 'pass' => $password?:user_password(),
                 'status' => $status,
                 'roles' => $roles,
-                'created' => REQUEST_TIME,
+                'created' => \Drupal::time()->getRequestTime(),
             ]
         );
 

--- a/src/Command/User/LoginUrlCommand.php
+++ b/src/Command/User/LoginUrlCommand.php
@@ -79,7 +79,7 @@ class LoginUrlCommand extends UserBase
           //validate if https is on uri
           $regx = '/^https:.*/s';
           if(preg_match($regx, $input->getOption('uri'))){
-              $timestamp = REQUEST_TIME;
+              $timestamp = \Drupal::time()->getRequestTime();
               $langcode = $userEntity->getPreferredLangcode();
               $url = Url::fromRoute('user.reset',
                   [

--- a/src/Command/User/RoleCommand.php
+++ b/src/Command/User/RoleCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Utils\DrupalApi;
+use Drupal\user\Entity\User;
 
 /**
  * Class DebugCommand
@@ -79,7 +80,7 @@ class RoleCommand extends Command
         $systemRoles = $this->drupalApi->getRoles();
 
         if (is_numeric($user)) {
-            $userObject = user_load($user);
+            $userObject = User::load($user);
         } else {
             $userObject = user_load_by_name($user);
         }

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -200,8 +200,8 @@ class Manager
         foreach ($this->extensions[$type] as $extension) {
             $name = $extension->getName();
 
-            $isInstalled = false;
-            if (property_exists($extension, 'status')) {
+            $isInstalled = $type=='module' && \Drupal::service('module_handler')->moduleExists($name);
+            if (!$isInstalled && property_exists($extension, 'status')) {
                 $isInstalled = ($extension->status)?true:false;
             }
             if (!$showInstalled && $isInstalled) {

--- a/src/Utils/Create/CommentData.php
+++ b/src/Utils/Create/CommentData.php
@@ -41,7 +41,7 @@ class CommentData extends Base
                         'entity_id' => $nid,
                         'entity_type' => 'node',
                         'field_name' => 'comment',
-                        'created' => REQUEST_TIME - mt_rand(0, $timeRange),
+                        'created' => \Drupal::time()->getRequestTime() - mt_rand(0, $timeRange),
                         'uid' => $this->getUserID(),
                         'status' => true,
                         'subject' => $this->getRandom()->sentences(mt_rand(1, $titleWords), true),

--- a/src/Utils/Create/NodeData.php
+++ b/src/Utils/Create/NodeData.php
@@ -45,7 +45,7 @@ class NodeData extends Base
                     [
                         'nid' => null,
                         'type' => $contentType,
-                        'created' => REQUEST_TIME - mt_rand(0, $timeRange),
+                        'created' => \Drupal::time()->getRequestTime() - mt_rand(0, $timeRange),
                         'uid' => $this->getUserID(),
                         'title' => $this->getRandom()->sentences(mt_rand(1, $titleWords), true),
                         'revision' => mt_rand(0, 1),
@@ -90,7 +90,7 @@ class NodeData extends Base
         $node->setTitle($this->getRandom()->sentences(mt_rand(1, 5), true));
         $node->setNewRevision(TRUE);
         $node->revision_log = "Revision number $count was created";
-        $node->setRevisionCreationTime(REQUEST_TIME);
+        $node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
         $node->save();
     }
 }

--- a/src/Utils/Create/UserData.php
+++ b/src/Utils/Create/UserData.php
@@ -47,7 +47,7 @@ class UserData extends Base
                         'pass' => $password?:$this->getRandom()->word(mt_rand(8, 16)),
                         'status' => mt_rand(0, 1),
                         'roles' => $roles[array_rand($roles)],
-                        'created' => REQUEST_TIME - mt_rand(0, $timeRange),
+                        'created' => \Drupal::time()->getRequestTime() - mt_rand(0, $timeRange),
                     ]
                 );
 

--- a/src/Utils/DrupalApi.php
+++ b/src/Utils/DrupalApi.php
@@ -263,7 +263,8 @@ class DrupalApi
         $kernel->invalidateContainer();
 
         // Prepare a NULL request.
-        $kernel->prepareLegacyRequest($request);
+        $kernel->boot();
+        $kernel->preHandle($request);
 
         foreach (Cache::getBins() as $bin) {
             $bin->deleteAll();

--- a/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-delete.php.twig
@@ -66,7 +66,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
    */
   public function getQuestion() {
     return $this->t('Are you sure you want to delete the revision from %revision-date?', [
-      '%revision-date' => format_date($this->revision->getRevisionCreationTime()),
+      '%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime()),
     ]);
   }
 
@@ -101,7 +101,7 @@ class {{ entity_class }}RevisionDeleteForm extends ConfirmFormBase {% endblock %
     $this->{{ entity_class }}Storage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('{{ label }}: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    $this->messenger()->addMessage(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    $this->messenger()->addMessage(t('Revision from %revision-date of {{ label }} %title has been deleted.', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.{{ entity_name }}.canonical',
        ['{{ entity_name }}' => $this->revision->id()]

--- a/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert-translation.php.twig
@@ -98,7 +98,7 @@ class {{ entity_class }}RevisionRevertTranslationForm extends {{ entity_class }}
 
     $latest_revision_translation->setNewRevision();
     $latest_revision_translation->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(REQUEST_TIME);
+    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
     return $latest_revision_translation;
   }

--- a/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
+++ b/templates/module/src/Entity/Form/entity-content-revision-revert.php.twig
@@ -138,7 +138,7 @@ class {{ entity_class }}RevisionRevertForm extends ConfirmFormBase {% endblock %
   protected function prepareRevertedRevision({{ entity_class }}Interface $revision, FormStateInterface $form_state) {
     $revision->setNewRevision();
     $revision->isDefaultRevision(TRUE);
-    $revision->setRevisionCreationTime(REQUEST_TIME);
+    $revision->setRevisionCreationTime(\Drupal::time()->getRequestTime());
 
     return $revision;
   }

--- a/templates/module/src/Plugin/Condition/condition.php.twig
+++ b/templates/module/src/Plugin/Condition/condition.php.twig
@@ -42,7 +42,7 @@ class {{ class_name }} extends ConditionPluginBase {% endblock %}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     // Sort all modules by their names.
-    $modules = system_rebuild_module_data();
+    $modules = \Drupal::service('extension.list.module')->getList();
     uasort($modules, 'system_sort_modules_by_info_name');
 
     $options = [NULL => t('Select a module')];
@@ -88,7 +88,7 @@ class {{ class_name }} extends ConditionPluginBase {% endblock %}
     }
 
     $module = $this->configuration['module'];
-    $modules = system_rebuild_module_data();
+    $modules = \Drupal::service('extension.list.module')->getList();
 
     return $modules[$module]->status;
   }
@@ -98,7 +98,7 @@ class {{ class_name }} extends ConditionPluginBase {% endblock %}
    */
   public function summary() {
     $module = $this->getContextValue('module');
-    $modules = system_rebuild_module_data();
+    $modules = \Drupal::service('extension.list.module')->getList();
 
     $status = ($modules[$module]->status)?t('enabled'):t('disabled');
 


### PR DESCRIPTION
Problem
Drupal 9.x removed a lot of functions marked as deprecated in Drupal 8.x which drupal-console still uses in places.

Solution
All functions marked for deprecation in Drupal 8.x have been replaced with those compatible with Drupal 9.x.