### PR TITLE
Remove default parameter before required parameter

### DIFF
--- a/src/Bootstrap/DrupalServiceModifier.php
+++ b/src/Bootstrap/DrupalServiceModifier.php
@@ -39,7 +39,7 @@ class DrupalServiceModifier implements ServiceModifierInterface
      * @param ConfigurationInterface $configuration
      */
     public function __construct(
-        $root = null,
+        $root,
         $serviceTag,
         $generatorTag,
         $configuration


### PR DESCRIPTION
Fix #4310

Since the later arguments are required this should be all that's needed.