### PR TITLE
Update DrupalServiceModifier.php

### DIFF
--- a/src/Bootstrap/DrupalServiceModifier.php
+++ b/src/Bootstrap/DrupalServiceModifier.php
@@ -39,7 +39,7 @@ class DrupalServiceModifier implements ServiceModifierInterface
      * @param ConfigurationInterface $configuration
      */
     public function __construct(
-        $root = null,
+        $root,
         $serviceTag,
         $generatorTag,
         $configuration


### PR DESCRIPTION
to resolve error :
<em class="placeholder">Deprecated function</em>: Optional parameter $root declared before required parameter $configuration is implicitly treated as a required parameter in <em class="placeholder">include()</em> (line <em class="placeholder">571</em> of <em class="placeholder">C:\Users\I21160Y\Documents\espace2-navigo\vendor\composer\ClassLoader.php</em>). <pre class="backtrace">include(&#039;C:\Users\I21160Y\Documents\espace2-navigo\web\core\includes\bootstrap.inc&#039;) (Line: 571)
Composer\Autoload\includeFile(&#039;C:\Users\I21160Y\Documents\espace2-navigo\vendor\composer/../drupal/console/src\Bootstrap\DrupalServiceModifier.php&#039;) (Line: 428)
Composer\Autoload\ClassLoader-&gt;loadClass(&#039;Drupal\Console\Bootstrap\DrupalServiceModifier&#039;) (Line: 157)
Drupal\Console\Bootstrap\Drupal-&gt;boot() (Line: 79)
require(&#039;C:\Users\I21160Y\Documents\espace2-navigo\vendor\drupal\console\bin\drupal.php&#039;) (Line: 4)
include(&#039;C:\Users\I21160Y\Documents\espace2-navigo\vendor\drupal\console\bin\drupal&#039;) (Line: 96)
</pre>