### PR TITLE
Rewrite all ProcessBuilder with Process

### DIFF
--- a/src/Command/Config/EditCommand.php
+++ b/src/Command/Config/EditCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Drupal\Component\Serialization\Yaml;
@@ -106,8 +106,7 @@ class EditCommand extends Command
         if (!$editor) {
             $editor = $this->getEditor();
         }
-        $processBuilder = new ProcessBuilder([$editor, $configFile]);
-        $process = $processBuilder->getProcess();
+        $process = new Process([$editor, $configFile]);
         $process->setTty('true');
         $process->run();
 
@@ -167,9 +166,7 @@ class EditCommand extends Command
             return trim($editor);
         }
 
-        $processBuilder = new ProcessBuilder(['bash']);
-        $process = $processBuilder->getProcess();
-        $process->setCommandLine('echo ${EDITOR:-${VISUAL:-vi}}');
+        $process = new Process(['bash', 'echo', '${EDITOR:-${VISUAL:-vi}}']);
         $process->run();
         $editor = $process->getOutput();
         $process->stop();

--- a/src/Command/Database/ClientCommand.php
+++ b/src/Command/Database/ClientCommand.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Command\Database;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Command\Shared\ConnectTrait;
 
@@ -63,9 +63,8 @@ class ClientCommand extends Command
             );
         }
 
-        $processBuilder = new ProcessBuilder([]);
-        $processBuilder->setArguments(explode(' ', $connection));
-        $process = $processBuilder->getProcess();
+        $arguments = explode(' ', $connection);
+        $process = new Process($arguments);
         $process->setTty('true');
         $process->run();
 

--- a/src/Command/Database/QueryCommand.php
+++ b/src/Command/Database/QueryCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Command\Shared\ConnectTrait;
 
@@ -123,9 +123,7 @@ class QueryCommand extends Command
             );
         }
 
-        $processBuilder = new ProcessBuilder();
-        $processBuilder->setArguments($args);
-        $process = $processBuilder->getProcess();
+        $process = new Process($args);
         $process->setTty('true');
         $process->run();
 

--- a/src/Command/Module/InstallCommand.php
+++ b/src/Command/Module/InstallCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Command\Shared\ProjectDownloadTrait;
 use Drupal\Console\Command\Shared\ModuleTrait;
@@ -189,13 +189,10 @@ class InstallCommand extends Command
             $module = $module_list;
 
             // Run the Composer require command.
-            $command = array_merge(['composer', 'require'], $composer_package_list);
-            $this->getIo()->info('Executing... ' . implode(' ', $command));
-            $processBuilder = new ProcessBuilder([]);
-            $processBuilder->setWorkingDirectory($this->appRoot);
-            $processBuilder->setArguments($command);
-            $processBuilder->inheritEnvironmentVariables();
-            $process = $processBuilder->getProcess();
+            $arguments = array_merge(['composer', 'require'], $composer_package_list);
+            $this->getIo()->info('Executing... ' . implode(' ', $arguments));
+            $process = new Process($arguments);
+            $process->setWorkingDirectory($this->appRoot);
             $process->setTty(true);
             $process->run();
 

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -10,7 +10,7 @@ namespace Drupal\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Utils\ConfigurationManager;
@@ -78,10 +78,8 @@ class ServerCommand extends Command
         $router = $this->configurationManager
             ->getVendorCoreDirectory() . 'router.php';
 
-        $processBuilder = new ProcessBuilder([$binary, '-S', $address, $router]);
-        $processBuilder->setTimeout(null);
-        $processBuilder->setWorkingDirectory($this->appRoot);
-        $process = $processBuilder->getProcess();
+        $process = new Process([$binary, '-S', $address, $router]);
+        $process->setWorkingDirectory($this->appRoot);
 
         $this->getIo()->success(
             sprintf(


### PR DESCRIPTION
* ProcessBuilder was deprecated in Symfony 3.4 and was removed in
  Symfony 4.0. Instead, Process should be used directly.
* Since Drupal 9 depends on Symfony 4, this rewrite is necessary
  for forward compatibility.
* Fixes #4330 