### PR TITLE
fix: Use service interfaces, not specific implementations.

### DIFF
--- a/src/Command/Update/ExecuteCommand.php
+++ b/src/Command/Update/ExecuteCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Core\State\StateInterface;
-use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Update\UpdateRegistry;
 use Drupal\Console\Utils\Site;
 use Drupal\Console\Extension\Manager;
@@ -34,7 +34,7 @@ class ExecuteCommand extends Command
     protected $state;
 
     /**
-     * @var ModuleHandler
+     * @var ModuleHandlerInterface
      */
     protected $moduleHandler;
 
@@ -69,7 +69,7 @@ class ExecuteCommand extends Command
      *
      * @param Site           $site
      * @param StateInterface $state
-     * @param ModuleHandler  $moduleHandler
+     * @param ModuleHandlerInterface  $moduleHandler
      * @param UpdateRegistry $postUpdateRegistry
      * @param Manager        $extensionManager
      * @param ChainQueue     $chainQueue
@@ -77,7 +77,7 @@ class ExecuteCommand extends Command
     public function __construct(
         Site $site,
         StateInterface $state,
-        ModuleHandler $moduleHandler,
+        ModuleHandlerInterface $moduleHandler,
         UpdateRegistry $postUpdateRegistry,
         Manager $extensionManager,
         ChainQueue $chainQueue


### PR DESCRIPTION
This is just a simple fix which replaces the references to `\Drupal\Core\Extension\ModuleHandler` with it's respective interface `\Drupal\Core\Extension\ModuleHandlerInterface`.

Fixes #4333